### PR TITLE
chore: ブランチ命名規則を明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Feature-Sliced Design を厳守する。
   - `main` … **開発のベース**。作業ブランチを切り、`main` に向けて PR を出す。`main` への直接コミットは避ける。
   - `release` … リリース済みコードを置くブランチ。リポジトリにアクセスした人に最初に表示させる目的（デフォルト表示）であり、**開発 PR のベースにはしない**。
 - **開発フロー**: Issue ごとに作業ブランチ（例 `feat/<issue>-...`）を `main` から切り、`main` に向けて PR を作成する。
+- **ブランチ命名**: `<type>/<issue>-<kebab-case-summary>` 形式。区切りは必ず**ハイフン（`-`）**を使い、**アンダースコア（`_`）は使わない**（例: ✅ `docs/144-requirements` / ❌ `docs/144_requirements`）。`type` はコミット規約と同じ（`feat` / `fix` / `docs` など）。
 - **コミット規約**: Conventional Commits + 日本語。
 
   ```


### PR DESCRIPTION
## 概要

ブランチ命名で区切りにアンダースコア（`_`）を使ってしまうミスを防ぐため、CLAUDE.md の Git 運用にブランチ命名規則を明文化する。

## 変更点

- `<type>/<issue>-<kebab-case-summary>` 形式を明記
- 区切りは必ずハイフン（`-`）を使い、アンダースコア（`_`）は使わない旨を ✅/❌ 例つきで追記

## テスト観点 / 動作確認

- ドキュメント（CLAUDE.md）のみの変更。