### PR TITLE
docs: ドキュメント索引(docs/README.md)を作成

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,71 @@
+# ProgPath ドキュメント
+
+ProgPath（再開発版）の設計ドキュメント群の索引。各ドキュメントへのリンク・概要・推奨する読む順序を示す。
+
+- 本プロジェクトは**ゼロから全面再開発中**。記述の正は to-be 設計。
+- リポジトリ運用（Git・コミット規約・開発フロー）は [../CLAUDE.md](../CLAUDE.md) を参照。
+
+---
+
+## 読む順序
+
+初めて読む場合は、上位（何を作るか）から下位（どう作るか）へ進むのが分かりやすい。
+
+1. **[requirements.md](./requirements.md)** — 何を・なぜ作るか（全体の源泉）
+2. **[features.md](./features.md)** — 画面ごとに何ができ、どう振る舞うか
+3. **[architecture.md](./architecture.md)** — どの技術で・どう組み立てるか
+4. **[directory-structure.md](./directory-structure.md)** — コードをどこに置くか
+5. **[db-design.md](./db-design.md)** — 何を・どう永続化するか
+6. **[glossary.md](./glossary.md)** — 用語の統一定義（随時参照）
+
+> `glossary.md` は通読より、他ドキュメントを読む際の**逆引き辞書**として使う。
+
+---
+
+## ドキュメント一覧
+
+| ドキュメント | 概要 |
+| --- | --- |
+| [requirements.md](./requirements.md) | 要件定義。利用前提・対象ユーザー・中心価値・機能/非機能要件・成功指標・スコープ外。 |
+| [features.md](./features.md) | 機能仕様。ホーム/迷路編集/AR実行/ダウンロードの画面別の振る舞いと確定ドメインルール。 |
+| [architecture.md](./architecture.md) | アーキテクチャ設計。システム構成図・技術スタックの責務・FSD 規則・データフロー・3D/AR 方式。 |
+| [directory-structure.md](./directory-structure.md) | ディレクトリ構成。`src/` 配下のレイヤー/スライス/セグメントと Public API 方針。 |
+| [db-design.md](./db-design.md) | DB 設計。迷路・フォルダのデータモデル・Zod スキーマ・TanStack DB/IndexedDB・QR シリアライズ。 |
+| [glossary.md](./glossary.md) | 用語集。ドメイン・コマンド・タイル種別・FSD・技術スタックの統一定義。 |
+
+---
+
+## ドキュメントの関係
+
+```mermaid
+flowchart TD
+    req["requirements.md<br/>要件定義"]
+    feat["features.md<br/>機能仕様"]
+    arch["architecture.md<br/>アーキテクチャ"]
+    dir["directory-structure.md<br/>ディレクトリ構成"]
+    db["db-design.md<br/>DB 設計"]
+    glo["glossary.md<br/>用語集"]
+
+    req --> feat
+    req --> arch
+    feat --> db
+    feat --> glo
+    arch --> dir
+    arch --> db
+    arch --> glo
+
+    style req fill:#e1f5ff
+    style glo fill:#fff3cd
+```
+
+- `requirements.md` が全体の源泉。
+- `features.md`（ドメインの振る舞い）と `architecture.md`（構造）が中核で、`directory-structure.md` と `db-design.md` を導く。
+- `glossary.md` は全体の用語を集約する横断的な参照。
+
+---
+
+## メンテナンス方針
+
+- ドキュメントの作成・編集・実装との同期は `docs` skill で行う（[../CLAUDE.md](../CLAUDE.md) 参照）。
+- 記述の正は to-be 設計。実装変更時は該当ドキュメントを同期する。
+- 〔要確認〕が付いた値・挙動は暫定。実機検証・運用で確定させる。


### PR DESCRIPTION
## 概要

`docs/` 配下の入口となる索引 `docs/README.md` を新規作成しました（エピック #143 の子。**ドキュメント本体の最後の1本**）。各ドキュメントへのリンク・概要・推奨する読む順序を提示します。

## 変更点

- 概要（docs/ の位置づけ・CLAUDE.md への導線）
- **読む順序**（requirements → features → architecture → directory-structure → db-design → glossary、各に理由付き。glossary は逆引き辞書として位置づけ）
- ドキュメント一覧（6本のリンク＋概要表）
- **ドキュメント関係図**（Mermaid：requirements を源泉に features/architecture が中核、glossary は横断参照）
- メンテナンス方針（docs skill・to-be が正・〔要確認〕の扱い）

## 関連 Issue

closes #150

## レビュー観点

- リンク先・概要が各ドキュメントの実態と一致しているか
- 読む順序・関係図が妥当か