### PR TITLE
docs: ブランチ命名に Issue 番号の付与を必須化

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -22,7 +22,7 @@ ProgPath のコミット規約（Conventional Commits + 日本語）に沿って
 ## 手順
 
 1. **ブランチ確認（必須・コミット直前に毎回）**: `git branch --show-current` で現在のブランチを確認する。
-   - `main` / `release` の場合は直接コミットせず、作業用ブランチ（例 `feat/<issue>-...`）への切り替えを提案する。
+   - `main` / `release` の場合は直接コミットせず、作業用ブランチへの切り替えを提案する。ブランチ名は CLAUDE.md のブランチ命名規則に従い、**対応する Issue があれば番号を必ず含める**（例: `feat/164-toolchain-bootstrap`）。
    - PR マージ後のローカル同期などで HEAD が `main` に移っていることがある。「さっきまで作業ブランチにいた」という前提で確認を省略しない。
 2. **差分レビュー**: `git status` と `git diff` を確認。
    - 一時ファイル・デバッグ用 `console.log`・不要アセットの混入をチェック。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,11 @@ Feature-Sliced Design を厳守する。
   - `release` … リリース済みコードを置くブランチ。リポジトリにアクセスした人に最初に表示させる目的（デフォルト表示）であり、**開発 PR のベースにはしない**。
 - **開発フロー**: Issue ごとに作業ブランチ（例 `feat/<issue>-...`）を `main` から切り、`main` に向けて PR を作成する。
 - **コミット前のブランチ確認（必須）**: `commit` skill を使うかどうかに関わらず、**コミットする直前に必ず `git branch --show-current` で現在のブランチを確認する**。`main` / `release` 上にいる場合は直接コミットせず、作業ブランチを切り直してから行う。PR マージ後のローカル同期などで HEAD が `main` に移っていることがあるため、「さっきまで作業ブランチにいた」前提で確認を省略しない。
-- **ブランチ命名**: `<type>/<issue>-<kebab-case-summary>` 形式。区切りは必ず**ハイフン（`-`）**を使い、**アンダースコア（`_`）は使わない**（例: ✅ `docs/144-requirements` / ❌ `docs/144_requirements`）。`type` はコミット規約と同じ（`feat` / `fix` / `docs` など）。
+- **ブランチ命名**: `<type>/<issue>-<kebab-case-summary>` 形式。
+  - **対応する Issue が存在する場合は、その Issue 番号を必ず含める**（例: ✅ `feat/164-toolchain-bootstrap` / ❌ `feat/toolchain-bootstrap`）。ブランチを切る前に対応 Issue の有無を確認する。
+  - 対応 Issue が無い場合に**限り**、番号を省いた `<type>/<kebab-case-summary>` 形式を許容する（例: `docs/branch-naming-issue-number`）。
+  - 区切りは必ず**ハイフン（`-`）**を使い、**アンダースコア（`_`）は使わない**（例: ✅ `docs/144-requirements` / ❌ `docs/144_requirements`）。
+  - `type` はコミット規約と同じ（`feat` / `fix` / `docs` など）。
 - **コミット規約**: Conventional Commits + 日本語。
 
   ```


### PR DESCRIPTION
## 概要

ブランチ命名規則を更新し、**対応する Issue が存在する場合は Issue 番号の付与を必須**にする。過去に番号無しブランチ（`docs/commit-branch-check-guard`）を作成した反省を反映。Issue が無い場合に限り、番号を省いた形式を許容する。

## 変更点

- **CLAUDE.md（ブランチ命名）**: 「対応 Issue があれば番号必須（例 `feat/164-...`）／無ければ `<type>/<summary>` を許容」を明文化。ブランチを切る前に対応 Issue の有無を確認する旨も追記
- **commit skill**: 作業ブランチ切り替えの提案時に、Issue 番号を含める旨を補強

## 関連 Issue

なし（運用ルールの改善）

## 確認観点

- [x] 「Issue があれば番号必須／無ければ省略可」が明確か
- [x] commit skill と CLAUDE.md の記述が整合しているか
