### PR TITLE
docs: getUserMedia 検証結果(#175 Phase A)を §7.2 に反映 + 再現 probe 追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,8 +267,36 @@ stateDiagram-v2
 
 ### 7.2 Tauri / WebView の留意点
 
-- Tauri のカメラ（`getUserMedia`）は OS の WebView 依存のため**要検証**（Windows = WebView2）。
-- カメラが使用不可の場合のフォールバック方針は未確定〔要確認〕。
+カメラ取得（`getUserMedia`）は AR 背景・QR 読み取りの共通土台で、WebView 実装に依存するため検証を要する（検証の詳細は Issue #175）。
+
+**検証状況（2026-06-27 時点 / Phase A: macOS・Web）**
+
+| 環境 | エンジン | 結果 |
+| --- | --- | --- |
+| Web（Safari / Chrome） | WebKit / Chromium | ✅ `getUserMedia`〜canvas 描画まで動作 |
+| Tauri × macOS（dev） | WKWebView | ✅ 同上（実機 `tauri dev` で確認） |
+| Tauri × Windows | WebView2（Chromium） | ⏳ 未検証（実機確保後・Phase B） |
+
+- Web 標的の両エンジン（WebKit＝WKWebView 相当 / Chromium＝WebView2 相当）はエンジンレベルで `getUserMedia` をサポート。Tauri×mac（実機 dev）でも動作確認済み。デプロイ主標的の **Windows/WebView2 実機検証は未完（Phase B）**。
+
+**必要設定（判明分）**
+
+- **macOS**: `src-tauri/Info.plist` に `NSCameraUsageDescription`（カメラ利用説明文）が必須。未設定だと TCC によりカメラアクセス時にアプリが落ちる。
+- **Tauri capability は不要**: `getUserMedia` は Web 標準 API であり Tauri の権限（capabilities）対象外。`core:default` のみで動作する。
+- **secure context が前提**: `getUserMedia` は secure context でのみ露出する。`tauri dev` は `http://127.0.0.1`（localhost 例外で secure）で配信するが、**本番 bundle は custom protocol**（macOS=`tauri://localhost` / Windows=`http://tauri.localhost`）で配信される。本番経路の secure-context 動作は Phase B で確認する。
+
+**残課題（Phase B / Windows・要実機）**
+
+- WebView2 の custom protocol（`http://tauri.localhost`）が secure context として扱われるか。
+- WebView2 の `PermissionRequested` をホスト（Rust）側で処理する必要があるか（既知の落とし穴。未処理だとカメラ要求が無音で拒否され得る）。
+
+**カメラ不可時のフォールバック方針（候補・暫定）**〔要確認〕
+
+授業は「2〜3 人で 1 台」が単位のため、1 台でもカメラ不可だと体験が崩れる。要件確定時に下記から選定する。
+
+- ① カメラ必須を前提に、不可時は明示エラー＋再試行/権限案内の導線を出す。
+- ② QR 読み取りは静止画撮影からのデコードに切り替える（連続スキャン不可時の代替）。
+- ③ AR 背景なしの 3D-only 表示にフォールバックする（AR の出口を縮退）。
 
 ### 7.3 配布
 
@@ -282,7 +310,7 @@ stateDiagram-v2
 | 箇所 | 内容 |
 | --- | --- |
 | 6.3 | 30fps / 起動 10 秒 / QR 1 秒以内の達成可否（実機検証） |
-| 7.2 | Tauri WebView での getUserMedia 動作 / カメラ不可時のフォールバック |
+| 7.2 | `getUserMedia`: mac/Web は検証済（#175 Phase A）。**Windows/WebView2 は未検証（Phase B・要実機）**。カメラ不可時フォールバックは候補のみで未確定 |
 | 7.3 | Desktop 版の配布元 |
 
 ---

--- a/spikes/175-getusermedia/README.md
+++ b/spikes/175-getusermedia/README.md
@@ -1,0 +1,48 @@
+# spike #175 — getUserMedia の WebView 動作検証
+
+AR 背景・QR 読み取りの共通土台である `getUserMedia` が各 WebView で動くかを検証する使い捨て probe。
+Issue #175 / 結果の要約は [docs/architecture.md §7.2](../../docs/architecture.md)。
+
+## probe.html
+
+secure context（https or localhost）で配信し、「カメラ開始」で `getUserMedia` → `<video>` → canvas 描画までを自己診断して結果 JSON を表示する。
+チェック項目: `isSecureContext` / `mediaDevices` 有無 / `enumerateDevices`（許可前後）/ `getUserMedia` 成否 / video 寸法 / canvas `drawImage` / フレーム非黒判定。
+
+## 再現手順
+
+### Web（ブラウザ）
+
+`file://` は secure context でないため localhost で配信する:
+
+```sh
+python3 -m http.server 8175 --directory spikes/175-getusermedia
+```
+
+ブラウザで `http://localhost:8175/probe.html` を開き「カメラ開始」→ 許可 → JSON を確認。
+
+- Safari = WebKit（≈ Tauri mac の WKWebView）/ Chrome・Edge = Chromium（≈ Windows の WebView2）。
+
+### Tauri（使い捨てシェル）
+
+1. Rust を導入（例: `mise use -g rust@stable`）。
+2. 最小シェルを作る:
+   ```sh
+   pnpm create tauri-app@latest spike -m pnpm -t vanilla --tauri-version 2 --identifier com.progpath.spike175 -y
+   ```
+3. `src/index.html` を `probe.html` に置き換える（`frontendDist` が `../src`）。
+4. macOS は `src-tauri/Info.plist` に `NSCameraUsageDescription` を追加（必須）。
+5. `pnpm install && pnpm tauri dev`。開いたウィンドウで「カメラ開始」→ 許可 → JSON。
+
+## Phase A 結果（2026-06-27 / macOS）
+
+Safari / Chrome / Tauri×mac(dev) いずれも **PASS**（getUserMedia〜canvas 描画まで）。詳細は docs/architecture.md §7.2 と Issue #175。
+
+- 注意: `tauri dev` は `http://127.0.0.1` 配信（localhost=secure context）。本番 bundle は custom protocol（mac=`tauri://localhost` / Win=`http://tauri.localhost`）。
+- 必要設定: macOS は Info.plist `NSCameraUsageDescription` 必須。Tauri capability は不要（Web 標準 API）。
+
+## Phase B（Windows / 未実施・要実機）チェックリスト
+
+- [ ] Tauri × Windows(WebView2) で probe を実行し `getUserMedia` 可否を確認
+- [ ] custom protocol（`http://tauri.localhost`）が `isSecureContext=true` か
+- [ ] WebView2 の `PermissionRequested` を Rust 側で処理する必要があるか
+- [ ] 必要設定（capability / 権限 / Windows プライバシー設定）を記録 → §7.2 を更新し #175 をクローズ

--- a/spikes/175-getusermedia/probe.html
+++ b/spikes/175-getusermedia/probe.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>#175 getUserMedia 検証 probe</title>
+    <style>
+      :root {
+        font-family: system-ui, sans-serif;
+        line-height: 1.5;
+      }
+      body {
+        margin: 0;
+        padding: 1rem 1.25rem;
+        max-width: 860px;
+      }
+      h1 {
+        font-size: 1.25rem;
+      }
+      button {
+        font-size: 1rem;
+        padding: 0.5rem 1rem;
+        margin-right: 0.5rem;
+        cursor: pointer;
+      }
+      #checks {
+        list-style: none;
+        padding: 0;
+      }
+      #checks li {
+        padding: 0.2rem 0;
+        font-variant-numeric: tabular-nums;
+      }
+      .ok::before {
+        content: "✅ ";
+      }
+      .ng::before {
+        content: "❌ ";
+      }
+      .na::before {
+        content: "⬜ ";
+      }
+      .media {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin: 1rem 0;
+      }
+      video,
+      canvas {
+        background: #111;
+        width: 360px;
+        max-width: 100%;
+        border: 1px solid #ccc;
+      }
+      textarea {
+        width: 100%;
+        height: 220px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+      }
+      .env {
+        background: #f5f5f5;
+        padding: 0.75rem;
+        border-radius: 6px;
+        font-size: 13px;
+      }
+      code {
+        background: #eee;
+        padding: 0 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>#175 getUserMedia 検証 probe</h1>
+    <p>
+      「カメラ開始」を押し、OS/ブラウザのカメラ許可ダイアログが出たら<strong>許可</strong>してください。
+      下の映像が出れば成功です。最後に <strong>結果 JSON をコピーして貼り戻して</strong>ください。
+    </p>
+
+    <div class="env" id="env">環境情報を取得中…</div>
+
+    <p style="margin-top: 1rem">
+      <button id="start">カメラ開始</button>
+      <button id="stop" disabled>停止</button>
+    </p>
+
+    <ul id="checks">
+      <li class="na" id="c-secure">isSecureContext</li>
+      <li class="na" id="c-api">navigator.mediaDevices.getUserMedia 存在</li>
+      <li class="na" id="c-enum-pre">enumerateDevices（許可前: videoinput 数）</li>
+      <li class="na" id="c-gum">getUserMedia({video:true}) 成功</li>
+      <li class="na" id="c-video">&lt;video&gt; に映像（videoWidth/Height &gt; 0）</li>
+      <li class="na" id="c-enum-post">enumerateDevices（許可後: ラベル取得）</li>
+      <li class="na" id="c-canvas">canvas へ 1 フレーム drawImage</li>
+      <li class="na" id="c-pixels">フレームが実体を持つ（非黒・画素にばらつき）</li>
+    </ul>
+
+    <div class="media">
+      <video id="video" autoplay playsinline muted></video>
+      <canvas id="canvas" width="360" height="270"></canvas>
+    </div>
+
+    <p>結果 JSON（これをコピーして貼り戻してください）:</p>
+    <textarea id="out" readonly></textarea>
+
+    <script>
+      const result = {
+        startedAt: new Date().toISOString(),
+        userAgent: navigator.userAgent,
+        protocol: location.protocol,
+        host: location.host,
+        isSecureContext: window.isSecureContext === true,
+        hasMediaDevices: !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia),
+        videoInputCountPre: null,
+        videoInputCountPost: null,
+        labelsVisibleAfterGrant: null,
+        getUserMedia: { ok: false, errorName: null, errorMessage: null },
+        videoDimensions: null,
+        canvasDrawOk: false,
+        frameIsReal: null,
+        pixelStats: null,
+        notes: [],
+      };
+
+      const $ = (id) => document.getElementById(id);
+      const set = (id, ok, text) => {
+        const el = $(id);
+        el.className = ok === null ? "na" : ok ? "ok" : "ng";
+        if (text) el.textContent = el.textContent.split("：")[0] + "：" + text;
+      };
+      const dump = () => {
+        $("out").value = JSON.stringify(result, null, 2);
+      };
+
+      // 環境情報を初期表示
+      $("env").innerHTML =
+        "<code>" +
+        result.userAgent +
+        "</code><br>" +
+        "protocol=" +
+        result.protocol +
+        " host=" +
+        (result.host || "(file)") +
+        " / isSecureContext=" +
+        result.isSecureContext +
+        " / mediaDevices=" +
+        result.hasMediaDevices;
+      set("c-secure", result.isSecureContext);
+      set("c-api", result.hasMediaDevices);
+      dump();
+
+      let stream = null;
+
+      async function enumerate() {
+        try {
+          const devices = await navigator.mediaDevices.enumerateDevices();
+          const cams = devices.filter((d) => d.kind === "videoinput");
+          return { count: cams.length, labels: cams.map((c) => c.label) };
+        } catch (e) {
+          result.notes.push("enumerateDevices error: " + e.name + " " + e.message);
+          return { count: -1, labels: [] };
+        }
+      }
+
+      async function start() {
+        $("start").disabled = true;
+        if (!result.hasMediaDevices) {
+          result.notes.push(
+            "navigator.mediaDevices.getUserMedia が存在しない（secure context か WebView 制約の可能性）",
+          );
+          dump();
+          return;
+        }
+
+        // 許可前 enumerate（通常ラベルは空）
+        const pre = await enumerate();
+        result.videoInputCountPre = pre.count;
+        set("c-enum-pre", pre.count > 0, "videoinput=" + pre.count);
+
+        // getUserMedia
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+          result.getUserMedia.ok = true;
+          set("c-gum", true);
+          $("stop").disabled = false;
+        } catch (e) {
+          result.getUserMedia.errorName = e.name;
+          result.getUserMedia.errorMessage = e.message;
+          set("c-gum", false, e.name + " / " + e.message);
+          dump();
+          return;
+        }
+
+        // video へ流し込み、寸法確認
+        const video = $("video");
+        video.srcObject = stream;
+        await new Promise((res) => {
+          if (video.readyState >= 1) return res();
+          video.onloadedmetadata = () => res();
+        });
+        await video.play().catch((e) => result.notes.push("video.play: " + e.message));
+        result.videoDimensions = { w: video.videoWidth, h: video.videoHeight };
+        set(
+          "c-video",
+          video.videoWidth > 0 && video.videoHeight > 0,
+          video.videoWidth + "x" + video.videoHeight,
+        );
+
+        // 許可後 enumerate（ラベルが出るはず）
+        const post = await enumerate();
+        result.videoInputCountPost = post.count;
+        result.labelsVisibleAfterGrant = post.labels.some((l) => l && l.length > 0);
+        set("c-enum-post", result.labelsVisibleAfterGrant, "labels=" + JSON.stringify(post.labels));
+
+        // 少し待ってから canvas へ 1 フレーム
+        await new Promise((r) => setTimeout(r, 400));
+        try {
+          const canvas = $("canvas");
+          const ctx = canvas.getContext("2d");
+          ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+          result.canvasDrawOk = true;
+          set("c-canvas", true);
+
+          // 画素統計（非黒・ばらつき判定）
+          const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+          let min = 255,
+            max = 0,
+            sum = 0,
+            n = 0;
+          for (let i = 0; i < data.length; i += 4 * 97) {
+            // 間引きサンプル
+            const lum = (data[i] + data[i + 1] + data[i + 2]) / 3;
+            min = Math.min(min, lum);
+            max = Math.max(max, lum);
+            sum += lum;
+            n++;
+          }
+          const avg = sum / n;
+          result.pixelStats = {
+            min: Math.round(min),
+            max: Math.round(max),
+            avg: Math.round(avg),
+            samples: n,
+          };
+          result.frameIsReal = max - min > 10 && avg > 2; // 真っ黒/単色でない
+          set(
+            "c-pixels",
+            result.frameIsReal,
+            "min=" +
+              result.pixelStats.min +
+              " max=" +
+              result.pixelStats.max +
+              " avg=" +
+              result.pixelStats.avg,
+          );
+        } catch (e) {
+          result.notes.push("canvas/getImageData error: " + e.name + " " + e.message);
+          set("c-canvas", false, e.name);
+        }
+        dump();
+      }
+
+      function stop() {
+        if (stream) stream.getTracks().forEach((t) => t.stop());
+        $("stop").disabled = true;
+        $("start").disabled = false;
+      }
+
+      $("start").addEventListener("click", () =>
+        start().catch((e) => {
+          result.notes.push("start() uncaught: " + e.name + " " + e.message);
+          dump();
+        }),
+      );
+      $("stop").addEventListener("click", stop);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要

#175「Tauri WebView での getUserMedia 検証」の **Phase A（macOS / Web）** の結果を docs に反映し、再現用 probe を追加する。製品コードの変更ではなく、検証結果のドキュメント同期 + 使い捨て検証ハーネスの保存。

## 変更点

- `docs/architecture.md` §7.2 を getUserMedia 検証結果に同期
  - 検証状況テーブル（Safari / Chrome / Tauri×mac = PASS、Windows = Phase B 未検証）
  - 必要設定（mac: `NSCameraUsageDescription` 必須 / Tauri capability 不要）
  - dev（`http://127.0.0.1`）と本番 bundle（custom protocol）の配信経路差
  - 残課題（Windows/WebView2 の secure context・`PermissionRequested`）
  - カメラ不可時のフォールバック候補（暫定・〔要確認〕）
- §8 未確定事項テーブルの 7.2 行を更新
- `spikes/175-getusermedia/`（probe.html + README）を追加 — Phase B(Windows) での再現・再利用用

## 関連 Issue

関連 #175（**closes しない**: Windows 実機での Phase B 完了までクローズしない）

## 検証観点 / 動作確認

- `vp check`（lint + format + 型チェック）exit 0
- Phase A 実機検証: Safari(WebKit) / Chrome(Chromium) / Tauri×mac(WKWebView dev) で `getUserMedia` 〜 canvas 描画まで PASS（生データは #175 コメント参照）
- `/verify` 観点: 本 PR は docs + 検証ハーネスのみで製品コードの挙動変更なし（ランタイムサーフェスなし）

### レビュアー確認ポイント
- §7.2 の記述が検証結果（#175 コメント）と一致しているか
- カメラ不可時フォールバック候補（①必須+再試行導線 / ②静止画デコード / ③3D-only）が「2〜3 人で 1 台」前提の判断材料として妥当か
