### PR TITLE
ci: GitHub Actions で lint/型/test/FSD境界/build を自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+# main 向け PR と main への push で品質チェックを自動実行する（#173）。
+# ローカル（mise run check / lint:fsd / test）と同一コマンドを CI でも走らせる。
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# 同一ブランチ/PR の進行中ジョブはキャンセルして無駄を省く。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise (mise.toml の node / pnpm を固定導入)
+        uses: jdx/mise-action@v2
+
+      - name: Resolve pnpm store path
+        run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint / Format / Typecheck (vp)
+        run: mise run check
+
+      - name: FSD dependency boundaries (dependency-cruiser)
+        run: mise run lint:fsd
+
+      - name: Test (Vitest)
+        run: mise run test
+
+      - name: Build (Vite+)
+        run: mise run build


### PR DESCRIPTION
## 概要

#173。main 向け PR / main への push で **lint・型・テスト・FSD 境界・ビルド**を GitHub Actions で自動実行する。これまでローカル（`mise run` / pre-push）頼みだった品質チェックを、GitHub 側で全 PR に対して機械的に保証する。

## 変更点

- `.github/workflows/ci.yml` を追加。
  - **トリガー**: `pull_request`(→ main) / `push`(→ main)。
  - **`jdx/mise-action`** で `mise.toml` の node 22.18.0 / pnpm 10.34.4 を固定導入 → ローカルと**同一の `mise run` タスク**を実行。
  - **ステップ**: `check`(lint+format+型) / `lint:fsd`(dependency-cruiser・#167) / `test`(Vitest) / `build`(Vite+)。
  - **最適化**: pnpm store をキャッシュ、`concurrency` で進行中の古い実行をキャンセル。

## 関連 Issue

closes #173（※デフォルトブランチが `release` のため自動クローズされない。マージ後に手動クローズ）

## 検証

- ローカルで各タスクは通過済み（`mise run check` / `mise run lint:fsd` は exit 0、`mise run test` は smoke 通過、`mise run build` 成功）。
- **本 PR 自体が CI のトリガー**になるため、この PR の Actions 実行で end-to-end を確認する（赤なら修正して再 push）。

## マージ後の次の一手（スコープ外）

- CI が1回緑になれば、ブランチ保護（必須チェック）の設定が可能になる。ポリシー（必須チェック／レビュー必須／管理者強制 等）を確定後に `gh api` か Settings UI で設定する（#173 の課題欄: 管理者判断）。
