### PR TITLE
build: Oxlint で型認識 lint とコーディング規約を強制

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from "vite-plus";
 
 // フォーマット/リント対象から外すパス（手書きの日本語ドキュメント・生成物・ロックファイル等）。
-// 手書きドキュメントを reformat させないための最小スコープ。型認識 lint・厳格ルール・
-// fmt/lint の最終ポリシーは #166 で確定する。
+// 手書きドキュメントを reformat させないための最小スコープ。
 const FORMAT_LINT_IGNORE = ["dist/**", "**/*.md", "public/**", "package.json", "pnpm-lock.yaml"];
 
 // Vite+ の統合設定。標準 Vite 設定に加え test(Vitest) / lint(Oxlint) / fmt(Oxfmt) を集約する。
-// 型チェック有効化(lint.options.typeCheck)と厳格 lint ルールは #166 で追加する。
+// lint は type-aware を有効化し、コーディング規約(any 禁止 / 型明示 / 命名 等)をルール化する(#166)。
 // Tauri 向けの本格配線(build.target 等)は #171 で行う。
 export default defineConfig({
   plugins: [],
@@ -25,6 +24,28 @@ export default defineConfig({
   },
   lint: {
     ignorePatterns: FORMAT_LINT_IGNORE,
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+    plugins: ["typescript", "unicorn", "react", "jsx-a11y", "import", "oxc"],
+    rules: {
+      // === CLAUDE.md 規約直結（error）===
+      "typescript/no-explicit-any": "error", // any 禁止（unknown + 型ガードを使う）
+      "typescript/explicit-function-return-type": [
+        "error",
+        {
+          allowExpressions: true,
+          allowTypedFunctionExpressions: true,
+          allowHigherOrderFunctions: true,
+        },
+      ],
+      "unicorn/filename-case": ["error", { case: "kebabCase" }], // ファイル名 kebab-case
+      "react/rules-of-hooks": "error",
+      // === 補助・スタイル（warn）===
+      "no-console": ["warn", { allow: ["warn", "error"] }], // log は warn、error/warn は許可
+      "react/exhaustive-deps": "warn",
+    },
   },
   fmt: {
     ignorePatterns: FORMAT_LINT_IGNORE,


### PR DESCRIPTION
## 概要

#166。Oxlint(vp) に **type-aware lint** を有効化し、CLAUDE.md のコーディング規約をルール化して機械強制する。

## 重要: これまで型チェックが効いていなかった

検証で、現状の `vp check` は `typeAware`/`typeCheck` 未設定のため **型チェックも `any` 禁止も実行していない**ことを確認（型エラーを仕込んでも素通り）。本 PR で初めて型エラー・`any` 等が `vp check` / CI / pre-push で弾かれるようになる。

## 変更点（`vite.config.ts` の `lint` ブロック）

- `options.typeAware/typeCheck` を有効化（tsgolint。tsconfig に `baseUrl` が無く互換）。
- `plugins`: typescript / unicorn / react / jsx-a11y / import / oxc。
- `rules`（規約直結 = **error**）:
  - `typescript/no-explicit-any`（any 禁止）
  - `typescript/explicit-function-return-type`（型明示。実用例外: allowExpressions / allowTypedFunctionExpressions / allowHigherOrderFunctions）
  - `unicorn/filename-case`（ファイル名 kebab-case）
  - `react/rules-of-hooks`
- `rules`（補助 = **warn**）: `no-console`（log のみ。error/warn は許可） / `react/exhaustive-deps`。
- 冒頭コメントを現状に更新。

## 関連 Issue

closes #166（※デフォルトブランチが `release` のため自動クローズ不可。マージ後に手動クローズ）

## 検証

- **型チェック/any**: probe（型エラー + any）は設定前は素通り → 有効化後に `TS2322` と `no-explicit-any` を検出。
- **型明示 / ファイル名 / console**: 違反サンプルで `explicit-function-return-type`(error) / `unicorn/filename-case`(error) / `no-console`(warn) を検出確認（2 errors + 1 warning）。サンプルは撤去済み。
- **skeleton**: `mise run check` / `mise run lint:fsd` ともに exit 0（既存コードを壊さない）。
- 本 PR の CI 実行で end-to-end を確認する。

## 確定した方針（合意済み）

- 規約直結 = error / スタイル = warn。
- `explicit-function-return-type` は実用重視（例外許容）。
- console は error/warn 許可・log は warn。

## スコープ外

- FSD 依存境界は #167（dependency-cruiser）で実装済み。
- 命名規約のうち変数/型/定数レベルは Oxlint の対応範囲に依存（ファイル名 kebab は確実に強制）。
