### PR TITLE
test: Vitest のテスト基盤を整備（環境・カバレッジ・規約・サンプル）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,18 @@ Feature-Sliced Design を厳守する。
 - **R3F**: 高頻度更新は `useFrame` 内で `ref.current` を直接操作し `setState` を避ける。アセットは `useGLTF`/`useLoader` でキャッシュ。`useFrame` 内では一時ベクトルを再利用して GC を抑制。
 - **コメント**: 公開関数は JSDoc。3D 座標変換など数式箇所は意図を残す。
 
+## テスト（要点）
+
+テスト基盤は Vitest（`vp` 同梱）。**この節は土台と最低限の規約**。「何を・どこまでテストするか」の戦略は別途定める（Issue #209）。
+
+- **実行**: `mise run test`（CI もローカルも同一入口）。カバレッジは `vp test --coverage`。**閾値ゲートは設けない**（計測のみ。本格運用は #209）。
+- **配置**: テスト対象と **co-location**（`foo.ts` の隣に `foo.test.ts`）。スライス内のセグメント（`model` / `lib` 等）に同居させる。
+- **命名**: `*.test.ts` / `*.test.tsx`。
+- **環境**: 既定 `node`（純粋ロジック中心）。DOM が必要なテストはファイル先頭に `// @vitest-environment jsdom`（or `happy-dom`）を付けて opt-in。DOM テスト基盤の本格導入は最初のコンポーネント着手時。
+- **import**: グローバル注入（`globals`）は使わず `import { describe, it, expect } from "vitest"` を明示。**同一スライス内は相対 import**、**他スライスは Public API（`index.ts`）経由**。
+- **規約緩和**: テストファイルは lint を一部緩和（`any` 許容・戻り値型省略可）。本番コードは緩めない。
+- **代表サンプル**: `src/shared/lib/clamp.test.ts`（疎通用スモークは `src/smoke.test.ts`）。
+
 ## Git 運用
 
 - **ブランチ**:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "4.1.9",
     "dependency-cruiser": "18.0.0",
     "lefthook": "2.1.9",
     "typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: 4.1.9
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       dependency-cruiser:
         specifier: 18.0.0
         version: 18.0.0
@@ -35,10 +38,10 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 0.2.1
-        version: 0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
+        version: 0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(vite@8.1.0(@types/node@26.0.1))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1))
 
 packages:
 
@@ -46,13 +49,30 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -66,8 +86,15 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -513,6 +540,15 @@ packages:
     peerDependencies:
       vitest: 4.1.9
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -697,6 +733,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -788,6 +827,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
@@ -811,6 +853,21 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -958,6 +1015,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1280,9 +1344,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@blazediff/core@1.9.1': {}
 
@@ -1302,7 +1379,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -1554,7 +1638,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.9(vite@8.1.0(@types/node@26.0.1))(vitest@4.1.9)
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(vite@8.1.0(@types/node@26.0.1))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -1570,13 +1654,29 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(vite@8.1.0(@types/node@26.0.1))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1))
+    optionalDependencies:
+      '@vitest/browser': 4.1.9(vite@8.1.0(@types/node@26.0.1))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -1684,6 +1784,12 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -1766,6 +1872,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-escaper@2.0.2: {}
+
   ignore@7.0.5: {}
 
   ini@4.1.1: {}
@@ -1782,6 +1890,21 @@ snapshots:
       is-path-inside: 4.0.0
 
   is-path-inside@4.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -1887,6 +2010,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
   minimist@1.2.8: {}
 
   mrmime@2.0.1: {}
@@ -1895,7 +2028,7 @@ snapshots:
 
   obug@2.1.3: {}
 
-  oxfmt@0.55.0(vite-plus@0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))):
+  oxfmt@0.55.0(vite-plus@0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -1918,7 +2051,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.55.0
       '@oxfmt/binding-win32-ia32-msvc': 0.55.0
       '@oxfmt/binding-win32-x64-msvc': 0.55.0
-      vite-plus: 0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
+      vite-plus: 0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -1929,7 +2062,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))):
+  oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.70.0
       '@oxlint/binding-android-arm64': 1.70.0
@@ -1951,7 +2084,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.70.0
       '@oxlint/binding-win32-x64-msvc': 1.70.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
+      vite-plus: 0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1))
 
   path-parse@1.0.7: {}
 
@@ -2092,7 +2225,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  vite-plus@0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)):
+  vite-plus@0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)):
     dependencies:
       '@oxc-project/types': 0.136.0
       '@oxlint/plugins': 1.68.0
@@ -2106,10 +2239,10 @@ snapshots:
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
       '@voidzero-dev/vite-plus-core': 0.2.1(@types/node@26.0.1)(typescript@6.0.3)
-      oxfmt: 0.55.0(vite-plus@0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)))
-      oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@26.0.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)))
+      oxfmt: 0.55.0(vite-plus@0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)))
+      oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)))
       oxlint-tsgolint: 0.23.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(vite@8.1.0(@types/node@26.0.1))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.1
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.1
@@ -2163,7 +2296,7 @@ snapshots:
       '@types/node': 26.0.1
       fsevents: 2.3.3
 
-  vitest@4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(vite@8.1.0(@types/node@26.0.1)):
+  vitest@4.1.9(@types/node@26.0.1)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(vite@8.1.0(@types/node@26.0.1)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.1))
@@ -2188,6 +2321,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.0.1
       '@vitest/browser-preview': 4.1.9(vite@8.1.0(@types/node@26.0.1))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 

--- a/src/shared/lib/clamp.test.ts
+++ b/src/shared/lib/clamp.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { clamp } from "./clamp";
+
+// 配置・命名規約のサンプル: テストは対象と co-location（`clamp.ts` の隣に `clamp.test.ts`）。
+// 同一スライス内なので Public API(index.ts) を介さず相対 import で内部実装を直接テストする。
+describe("clamp", () => {
+  it("範囲内の値はそのまま返す", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("下限未満は min に丸める", () => {
+    expect(clamp(-3, 0, 10)).toBe(0);
+  });
+
+  it("上限超は max に丸める", () => {
+    expect(clamp(42, 0, 10)).toBe(10);
+  });
+
+  it("境界値(min/max)は含む", () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+
+  it("min > max は RangeError を投げる", () => {
+    expect(() => clamp(5, 10, 0)).toThrow(RangeError);
+  });
+});

--- a/src/shared/lib/clamp.ts
+++ b/src/shared/lib/clamp.ts
@@ -1,0 +1,24 @@
+/**
+ * 値を [min, max] の範囲に収める。
+ *
+ * loop 回数やグリッドサイズなど「範囲を持つ整数・数値」を扱う箇所で用いる
+ * フレームワーク非依存の純粋関数。
+ *
+ * @param value 対象の値
+ * @param min 下限（含む）
+ * @param max 上限（含む）
+ * @returns min 未満なら min、max 超なら max、範囲内ならそのまま
+ * @throws min > max の場合（呼び出し側のバグを早期に検出する）
+ */
+export const clamp = (value: number, min: number, max: number): number => {
+  if (min > max) {
+    throw new RangeError(`clamp: min(${min}) は max(${max}) 以下である必要があります`);
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -7,4 +7,4 @@
  * 公開対象を個別に明示し、公開シンボルは実装着手時に追加する
  * （→ docs/directory-structure.md 2.2）。
  */
-export {};
+export { clamp } from "./clamp";

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-// ツールチェーン疎通確認用のスモークテスト。テスト規約・本格的なテストは #172 で整備する。
+// ツールチェーン（vp test / Vitest）疎通確認用のスモークテスト。
+// テストの配置・命名規約と代表サンプルは shared/lib/clamp.test.ts を参照（→ CLAUDE.md「テスト」）。
 describe("toolchain smoke", () => {
   it("Vitest(vp test)が実行できる", () => {
     expect(1 + 1).toBe(2);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,28 @@ export default defineConfig({
     strictPort: true,
   },
   test: {
+    // 既定は node 環境（純粋ロジック中心）。DOM が要るテストはファイル先頭に
+    // `// @vitest-environment jsdom`(or happy-dom) を付けて opt-in する（規約は CLAUDE.md）。
+    // DOM テスト基盤の本格導入は最初のコンポーネント着手時（#187 等）。
+    environment: "node",
+    // グローバル注入は使わない。各テストで `import { describe, it, expect } from "vitest"` を明示する。
+    globals: false,
     include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      // v8（高速・追加ビルド不要）。閾値(thresholds)は設けない＝計測のみ。
+      // 合格ラインの本格運用はドメインのテスト方針（#209）で決める。
+      provider: "v8",
+      reporter: ["text", "html"], // text=コンソール要約 / html=詳細（coverage/ は .gitignore 済）
+      // include で指定したファイルは未テストでも 0% として報告される（v4 既定。「どこが未チェックか」の地図になる）。
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}", // テスト自身
+        "src/**/*.d.ts", // 型宣言
+        "src/**/index.ts", // Public API（再エクスポートのみでロジックなし）
+        "src/main.tsx", // アプリのエントリ
+        "src/vite-env.d.ts",
+      ],
+    },
   },
   lint: {
     ignorePatterns: FORMAT_LINT_IGNORE,


### PR DESCRIPTION
## 概要

テスト基盤（Vitest）の土台と最低限の規約を整備する（#172）。`vp` 同梱 Vitest のため導入は軽量で、内容は「設定 ＋ サンプル ＋ 規約」に絞っている。テスト戦略・カバレッジ閾値の本格運用は #209 で別途定める。

## 変更点

- **依存追加**: `@vitest/coverage-v8`（vitest と同じ `4.1.9` に固定）
- **`vite.config.ts` の `test` 拡充**
  - `environment: "node"` を明示（DOM が要るテストはファイル先頭 `// @vitest-environment` で opt-in）
  - `globals: false` を明示（各テストで `import { ... } from "vitest"`）
  - `coverage`: provider v8 / reporter `text`+`html` / include・exclude 設定 / **閾値ゲートは設けない**（計測のみ）
- **代表サンプル**: `src/shared/lib/clamp`（純粋関数）＋ co-located テスト `clamp.test.ts` を追加。`shared/lib` の Public API に `clamp` を公開
- **`src/smoke.test.ts`**: ツールチェーン疎通用として位置づけを更新
- **`CLAUDE.md`**: 「テスト（要点）」節を追加（実行・配置(co-location)・命名・環境・import 規約・規約緩和・#209 への引き継ぎ）

## 設計方針（背景）

- `mise`（入口・版固定）→ `vp`（統合 CLI）→ Vitest という委譲構成。CI もローカルも `mise run test` に揃え「ローカルで通るのに CI で落ちる」を防ぐ。
- 設定は単一の正に集約（テスト挙動=`vite.config.ts` / path=`tsconfig.json` / 版=`mise.toml`）。
- 環境は「node 既定 ＋ DOM は per-file opt-in」。DOM/コンポーネントテスト基盤の本格導入は最初のコンポーネント着手時（#187 等）。

## 動作確認

- `mise run test` → 2 files / 6 tests pass
- `vp test --coverage` → v8 で計測動作（`coverage/` 生成、.gitignore 済）
- `mise run check`（lint+fmt+型）→ pass（format 40 / lint+type 33）
- `mise run lint:fsd`（FSD 境界）→ 違反なし

## DoD（#172）

- [x] `vp test` / `mise run test` で実行できる
- [x] サンプルのユニットテストが通る
- [x] 配置・命名規約（`*.test.ts`）が定まっている
- [x] CI から実行可能

## 関連

closes #172

> 注: デフォルトブランチが `release` のため、`main` への本 PR マージでは #172 は自動クローズされない。マージ後に手動でクローズする。
