### PR TITLE
feat(shared/qr): qr-scanner ラッパで QR デコード I/F を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-three/fiber": "^9.6.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.23.0",
+    "qr-scanner": "^1.4.2",
     "radix-ui": "^1.6.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@19.2.7)
+      qr-scanner:
+        specifier: ^1.4.2
+        version: 1.4.2
       radix-ui:
         specifier: ^1.6.1
         version: 1.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2209,6 +2212,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  qr-scanner@1.4.2:
+    resolution: {integrity: sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==}
 
   radix-ui@1.6.1:
     resolution: {integrity: sha512-QXDXJtB6sK83mLASONYUZCauatcWb+knFviFpN1EhtdbbmlsRmzCLrbZSKztnNiem2KOHIBbiDbauVB7SORXMw==}
@@ -4490,6 +4496,10 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  qr-scanner@1.4.2:
+    dependencies:
+      '@types/offscreencanvas': 2019.7.3
 
   radix-ui@1.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/src/shared/qr/index.ts
+++ b/src/shared/qr/index.ts
@@ -1,11 +1,16 @@
 /**
  * Public API — `shared/qr`
  *
- * QR デコーダ抽象。`qr-scanner` を内部実装とし、デコード I/F を提供する
- * （実装は差し替え可能）。
+ * QR デコーダ抽象。`qr-scanner`（jsQR を Web Worker でラップ／対応環境ではネイティブ
+ * BarcodeDetector）を内部実装とし、デコード I/F を提供する（実装は差し替え可能）。
+ * デコードはメインスレッド外で走り、3D/AR の描画スレッドを塞がない。
  *
- * 他スライスからの import はこの index.ts 経由のみ。`export * from` は使わず
- * 公開対象を個別に明示し、公開シンボルは実装着手時に追加する
+ * 返すのは QR の生ペイロード文字列で、命令としての意味解釈・妥当性検証はしない（透過返却）。
+ * コマンド化・スタック管理は上位（`features/command-management`, #186）が担う。迷路共有 QR の
+ * 解凍（#201）も別スライスの責務。
+ *
+ * 他スライスからの import はこの index.ts 経由のみ。`export * from` は使わず公開対象を明示する
  * （→ docs/directory-structure.md 2.2）。
  */
-export {};
+export { decodeQr } from "./model/decode-qr";
+export type { QrSource } from "./model/decode-qr";

--- a/src/shared/qr/index.ts
+++ b/src/shared/qr/index.ts
@@ -14,3 +14,6 @@
  */
 export { decodeQr } from "./model/decode-qr";
 export type { QrSource } from "./model/decode-qr";
+
+export { createQrScanLoop } from "./model/qr-scan-loop";
+export type { QrScanLoop, QrScanLoopOptions, QrResultHandler } from "./model/qr-scan-loop";

--- a/src/shared/qr/model/decode-qr.test.ts
+++ b/src/shared/qr/model/decode-qr.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// qr-scanner を差し替え、Worker/DOM 無しの node 環境で decodeQr のロジックだけを検証する。
+vi.mock("qr-scanner", () => {
+  const QrScannerMock: any = vi.fn();
+  QrScannerMock.scanImage = vi.fn();
+  QrScannerMock.createQrEngine = vi.fn();
+  QrScannerMock.NO_QR_CODE_FOUND = "No QR code found";
+  return { default: QrScannerMock };
+});
+
+// モジュールレベルの共有エンジンをテストごとに初期化するため、resetModules 後に動的 import する。
+const load = async () => {
+  const QrScanner = (await import("qr-scanner")).default as any;
+  const { decodeQr } = await import("./decode-qr");
+  return { QrScanner, decodeQr };
+};
+
+const source = {} as HTMLVideoElement;
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("decodeQr", () => {
+  it("QR を検出したらデコード文字列を返す", async () => {
+    const { QrScanner, decodeQr } = await load();
+    QrScanner.createQrEngine.mockResolvedValue({});
+    QrScanner.scanImage.mockResolvedValue({ data: "forward", cornerPoints: [] });
+
+    expect(await decodeQr(source)).toBe("forward");
+    expect(QrScanner.scanImage).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({ returnDetailedScanResult: true }),
+    );
+  });
+
+  it("QR 未検出（文字列 throw）は null を返す", async () => {
+    const { QrScanner, decodeQr } = await load();
+    QrScanner.createQrEngine.mockResolvedValue({});
+    QrScanner.scanImage.mockRejectedValue("No QR code found");
+
+    expect(await decodeQr(source)).toBeNull();
+  });
+
+  it("QR 未検出（Error throw）も null を返す", async () => {
+    const { QrScanner, decodeQr } = await load();
+    QrScanner.createQrEngine.mockResolvedValue({});
+    QrScanner.scanImage.mockRejectedValue(new Error("No QR code found"));
+
+    expect(await decodeQr(source)).toBeNull();
+  });
+
+  it("未検出以外の失敗は再 throw する", async () => {
+    const { QrScanner, decodeQr } = await load();
+    QrScanner.createQrEngine.mockResolvedValue({});
+    QrScanner.scanImage.mockRejectedValue(new Error("engine boom"));
+
+    await expect(decodeQr(source)).rejects.toThrow("engine boom");
+  });
+
+  it("エンジンは生成後に使い回す（複数回デコードしても createQrEngine は 1 回）", async () => {
+    const { QrScanner, decodeQr } = await load();
+    QrScanner.createQrEngine.mockResolvedValue({});
+    QrScanner.scanImage.mockResolvedValue({ data: "x", cornerPoints: [] });
+
+    await decodeQr(source);
+    await decodeQr(source);
+
+    expect(QrScanner.createQrEngine).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/qr/model/decode-qr.ts
+++ b/src/shared/qr/model/decode-qr.ts
@@ -1,0 +1,82 @@
+/**
+ * QR 単発デコード（FSD: shared/qr/model）
+ *
+ * `qr-scanner` を内部実装とし、1 枚のソースから QR をデコードして生の文字列を返す薄いラッパ。
+ * デコードはエンジン（jsQR の Web Worker / ネイティブ BarcodeDetector）で実行され、メインスレッド
+ * （3D/AR 描画）を塞がない。連続スキャンは `createQrScanLoop`（qr-scan-loop.ts）を使う。
+ */
+import QrScanner from "qr-scanner";
+
+/**
+ * QR デコードの入力ソース。カメラ映像（`HTMLVideoElement`）を主用途とし、静的画像・キャンバス・
+ * `ImageBitmap` / `Blob`・データ URL 文字列等も受け付ける（qr-scanner の受理型の実用サブセット）。
+ */
+export type QrSource =
+  | HTMLVideoElement
+  | HTMLImageElement
+  | HTMLCanvasElement
+  | ImageBitmap
+  | Blob
+  | string;
+
+/**
+ * qr-scanner のエンジン（Worker / BarcodeDetector）生成 Promise の型。
+ * BarcodeDetector 型は qr-scanner が公開しておらず名前で参照できないため、戻り値から導出する。
+ */
+type QrEnginePromise = ReturnType<typeof QrScanner.createQrEngine>;
+
+// scanImage の qrEngine には Promise をそのまま渡せる。エンジン生成は高コストなためモジュールで
+// 一度だけ生成し、以降の単発デコードで使い回す（theme-store と同じモジュールシングルトン方式）。
+// 環境により jsQR の Web Worker かネイティブ BarcodeDetector を返す。いずれもデコードはメイン
+// スレッド外で走る。
+let sharedEnginePromise: QrEnginePromise | null = null;
+
+const getSharedEngine = (): QrEnginePromise => {
+  sharedEnginePromise ??= QrScanner.createQrEngine();
+  return sharedEnginePromise;
+};
+
+// canvas を使い回して毎回の生成・GC を抑える。DOM が無い環境（node テスト等）では null を渡し、
+// qr-scanner 側の既定生成に委ねる。
+let sharedCanvas: HTMLCanvasElement | null = null;
+
+const getSharedCanvas = (): HTMLCanvasElement | null => {
+  if (typeof document === "undefined") return null;
+  sharedCanvas ??= document.createElement("canvas");
+  return sharedCanvas;
+};
+
+/**
+ * QR 未検出（qr-scanner が `NO_QR_CODE_FOUND` を投げる正常系）かを判定する内部ヘルパ。
+ * `decodeQr` からのみ使い、Public API では公開しない。
+ */
+const isNoQrCodeFound = (error: unknown): boolean =>
+  error === QrScanner.NO_QR_CODE_FOUND ||
+  (error instanceof Error && error.message === QrScanner.NO_QR_CODE_FOUND);
+
+/**
+ * 単一のソースから QR を 1 回デコードし、埋め込まれた文字列を返す。
+ *
+ * デコードは qr-scanner のエンジン（Web Worker / BarcodeDetector）で実行され、メインスレッドを
+ * 塞がない。QR が見つからない場合は例外ではなく `null` を返す。
+ *
+ * 返す文字列は QR の生ペイロードで、**意味解釈・妥当性検証はしない**（透過返却）。命令文字列
+ * としての解釈・コマンド化は上位（`features/command-management`, #186）が担う。
+ *
+ * @param source デコード対象（カメラ映像・画像・キャンバス・`Blob`・データ URL 等）
+ * @returns デコードした文字列。QR 未検出時は `null`
+ * @throws QR 未検出以外の理由で失敗した場合（デコードエンジンの生成失敗等）
+ */
+export const decodeQr = async (source: QrSource): Promise<string | null> => {
+  try {
+    const result = await QrScanner.scanImage(source, {
+      qrEngine: getSharedEngine(),
+      canvas: getSharedCanvas(),
+      returnDetailedScanResult: true,
+    });
+    return result.data;
+  } catch (error) {
+    if (isNoQrCodeFound(error)) return null;
+    throw error;
+  }
+};

--- a/src/shared/qr/model/qr-scan-loop.test.ts
+++ b/src/shared/qr/model/qr-scan-loop.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ループはデコードを decodeQr に委譲する。ここではループの間引き・ライフサイクル制御だけを
+// 検証したいので decodeQr をモックする（qr-scanner には触れない）。
+vi.mock("./decode-qr", () => ({
+  decodeQr: vi.fn(),
+}));
+
+import { decodeQr } from "./decode-qr";
+import { createQrScanLoop } from "./qr-scan-loop";
+
+const decodeQrMock = vi.mocked(decodeQr);
+
+// requestVideoFrameCallback を持たない stub → setTimeout 経路（fake timers で決定的に検証できる）。
+const makeVideo = (readyState = 2) =>
+  ({ readyState, HAVE_CURRENT_DATA: 2 }) as unknown as HTMLVideoElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  decodeQrMock.mockResolvedValue("forward");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createQrScanLoop", () => {
+  it("start で連続スキャンを開始し、検出文字列で onResult を呼ぶ", async () => {
+    const video = makeVideo();
+    const onResult = vi.fn();
+    const loop = createQrScanLoop(video, onResult, { maxScansPerSecond: 10 });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(decodeQrMock).toHaveBeenCalledTimes(1);
+    expect(decodeQrMock).toHaveBeenCalledWith(video);
+    expect(onResult).toHaveBeenCalledWith("forward");
+    loop.destroy();
+  });
+
+  it("QR 未検出(null)では onResult を呼ばない", async () => {
+    decodeQrMock.mockResolvedValue(null);
+    const onResult = vi.fn();
+    const loop = createQrScanLoop(makeVideo(), onResult);
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(decodeQrMock).toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+    loop.destroy();
+  });
+
+  it("デコード失敗は onError に渡す", async () => {
+    decodeQrMock.mockRejectedValue(new Error("boom"));
+    const onError = vi.fn();
+    const loop = createQrScanLoop(makeVideo(), vi.fn(), { onError });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    loop.destroy();
+  });
+
+  it("stop 以降はスキャンしない", async () => {
+    const loop = createQrScanLoop(makeVideo(), vi.fn(), { maxScansPerSecond: 10 });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+    const before = decodeQrMock.mock.calls.length;
+
+    loop.stop();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(decodeQrMock).toHaveBeenCalledTimes(before);
+    loop.destroy();
+  });
+
+  it("maxScansPerSecond を超えて頻繁にスキャンしない", async () => {
+    const loop = createQrScanLoop(makeVideo(), vi.fn(), { maxScansPerSecond: 5 });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const calls = decodeQrMock.mock.calls.length;
+    expect(calls).toBeGreaterThanOrEqual(4);
+    expect(calls).toBeLessThanOrEqual(6);
+    loop.destroy();
+  });
+
+  it("destroy 後はスキャンせず、start しても再開しない", async () => {
+    const loop = createQrScanLoop(makeVideo(), vi.fn());
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(100);
+    const before = decodeQrMock.mock.calls.length;
+
+    loop.destroy();
+    loop.start(); // 無視される
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(decodeQrMock).toHaveBeenCalledTimes(before);
+  });
+
+  it("映像未準備(readyState<HAVE_CURRENT_DATA)ではスキャンしない", async () => {
+    const loop = createQrScanLoop(makeVideo(0), vi.fn());
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(decodeQrMock).not.toHaveBeenCalled();
+    loop.destroy();
+  });
+
+  it("maxScansPerSecond が正の有限数でなければ RangeError", () => {
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => createQrScanLoop(makeVideo(), vi.fn(), { maxScansPerSecond: bad })).toThrow(
+        RangeError,
+      );
+    }
+  });
+
+  it("maxScansPerSecond=0.5 は許容（約2秒に1回）", async () => {
+    const loop = createQrScanLoop(makeVideo(), vi.fn(), { maxScansPerSecond: 0.5 });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const calls = decodeQrMock.mock.calls.length;
+    expect(calls).toBeGreaterThanOrEqual(1);
+    expect(calls).toBeLessThanOrEqual(2);
+    loop.destroy();
+  });
+});

--- a/src/shared/qr/model/qr-scan-loop.ts
+++ b/src/shared/qr/model/qr-scan-loop.ts
@@ -1,0 +1,144 @@
+/**
+ * QR 連続スキャンループ（FSD: shared/qr/model）
+ *
+ * 呼び出し側が用意した `HTMLVideoElement`（ストリームは #180 `shared/camera` や widget が供給）を
+ * 入力に、`decodeQr` で QR を連続デコードし、成功時に生の文字列をコールバック通知する。
+ * デコード本体とエンジン（Worker/BarcodeDetector）は `decode-qr.ts` に集約し、ここはスキャンの
+ * 間引き・ライフサイクル制御に専念する（DRY）。**getUserMedia は呼ばない**（カメラ所有は #180）。
+ *
+ * スキャンは `requestVideoFrameCallback`（対応時）または `setTimeout` で回し、`maxScansPerSecond`
+ * で間引く。返す文字列は透過（意味解釈・重複除去・ループ構築中の読取停止は上位 #186 の責務）。
+ */
+import { decodeQr } from "./decode-qr";
+
+/** デコード成功時に生の QR 文字列を受け取るハンドラ。 */
+export type QrResultHandler = (data: string) => void;
+
+/** 連続スキャンの設定。 */
+export interface QrScanLoopOptions {
+  /** 1 秒あたりの最大スキャン回数（既定 10）。正の有限数のみ。低スペック端末の負荷を抑える間引き。 */
+  maxScansPerSecond?: number;
+  /** QR 未検出以外のデコード失敗を受け取る任意ハンドラ。 */
+  onError?: (error: unknown) => void;
+}
+
+/** 連続スキャンの制御ハンドル。 */
+export interface QrScanLoop {
+  /** スキャンを開始する（`destroy` 済み・実行中は無視）。 */
+  start: () => void;
+  /** スキャンを停止する（`start` で再開できる）。 */
+  stop: () => void;
+  /** 停止する。以降 `start` しても再開しない。 */
+  destroy: () => void;
+}
+
+/** 既定の 1 秒あたり最大スキャン回数。 */
+const DEFAULT_MAX_SCANS_PER_SECOND = 10;
+
+/**
+ * `requestVideoFrameCallback` に対応する video かを判定する型ガード。
+ * この API は TS lib への収録状況が環境により異なるため、lib 依存を避けて自前で検出する。
+ */
+interface VideoFrameCallbackCapable {
+  requestVideoFrameCallback: (callback: (now: number) => void) => number;
+  cancelVideoFrameCallback: (handle: number) => void;
+}
+
+const supportsVideoFrameCallback = (
+  video: HTMLVideoElement,
+): video is HTMLVideoElement & VideoFrameCallbackCapable =>
+  typeof (video as Partial<VideoFrameCallbackCapable>).requestVideoFrameCallback === "function";
+
+/**
+ * video 要素を連続スキャンして QR 文字列をコールバック通知するループを生成する。
+ *
+ * @param video スキャン対象。`srcObject` へのストリーム供給・再生は呼び出し側の責務
+ * @param onResult QR デコード成功ごとに生の文字列で呼ばれる
+ * @param options 間引き回数・エラーハンドラ
+ * @returns start / stop / destroy を持つ制御ハンドル
+ * @throws maxScansPerSecond が正の有限数でない場合（呼び出し側のバグを早期に検出する）
+ */
+export const createQrScanLoop = (
+  video: HTMLVideoElement,
+  onResult: QrResultHandler,
+  options: QrScanLoopOptions = {},
+): QrScanLoop => {
+  const { maxScansPerSecond = DEFAULT_MAX_SCANS_PER_SECOND, onError } = options;
+  if (!Number.isFinite(maxScansPerSecond) || maxScansPerSecond <= 0) {
+    throw new RangeError(
+      `createQrScanLoop: maxScansPerSecond は正の有限数である必要があります (received: ${maxScansPerSecond})`,
+    );
+  }
+  const minIntervalMs = 1000 / maxScansPerSecond;
+
+  let running = false;
+  let destroyed = false;
+  // 1 フレームのデコードが進行中かどうか（重複起動を防ぐ）。
+  let scanning = false;
+  // 直近スキャン時刻。初回は必ず走るよう -∞ で初期化する。
+  let lastScanAt = Number.NEGATIVE_INFINITY;
+  let rvfcHandle: number | null = null;
+  let timerHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const scanOnce = async (): Promise<void> => {
+    if (!running || scanning) return;
+    // 映像がまだ 1 フレームも来ていないときはスキップ（未準備時のデコード失敗・空フレームを避ける）。
+    if (video.readyState < video.HAVE_CURRENT_DATA) return;
+    const now = Date.now();
+    if (now - lastScanAt < minIntervalMs) return;
+    lastScanAt = now;
+    scanning = true;
+    try {
+      const data = await decodeQr(video);
+      if (data !== null && running) onResult(data);
+    } catch (error) {
+      onError?.(error);
+    } finally {
+      scanning = false;
+    }
+  };
+
+  const scheduleNext = (): void => {
+    if (!running) return;
+    if (supportsVideoFrameCallback(video)) {
+      rvfcHandle = video.requestVideoFrameCallback(() => tick());
+    } else {
+      timerHandle = setTimeout(() => tick(), minIntervalMs);
+    }
+  };
+
+  const tick = (): void => {
+    if (!running) return;
+    void scanOnce();
+    scheduleNext();
+  };
+
+  const clearScheduled = (): void => {
+    if (rvfcHandle !== null && supportsVideoFrameCallback(video)) {
+      video.cancelVideoFrameCallback(rvfcHandle);
+    }
+    rvfcHandle = null;
+    if (timerHandle !== null) {
+      clearTimeout(timerHandle);
+      timerHandle = null;
+    }
+  };
+
+  const start = (): void => {
+    if (destroyed || running) return;
+    running = true;
+    scheduleNext();
+  };
+
+  const stop = (): void => {
+    running = false;
+    clearScheduled();
+  };
+
+  const destroy = (): void => {
+    destroyed = true;
+    stop();
+  };
+
+  return { start, stop, destroy };
+};


### PR DESCRIPTION
## 概要
ProgPath の中心価値「QRカードで命令を作る」の最下層となる `shared/qr` スライスを実装。カメラ映像/画像から QR をデコードし、**命令文字列を透過返却するデコード I/F** を提供する。デコードは qr-scanner のエンジン（Web Worker / 対応環境ではネイティブ BarcodeDetector）で実行し、3D/AR の描画スレッドを塞がない。

## 変更内容（3コミット）
- **build**: qr-scanner 1.4.2 を依存追加（vp install 経由）
- **feat**: `decodeQr(source)` — 単発デコード。QR 未検出は `null`。エンジン/canvas をモジュール共有で再利用
- **feat**: `createQrScanLoop(video, onResult, options)` — video を throttle して連続スキャン。デコードは `decodeQr` に委譲（DRY）。start/stop/destroy。`maxScansPerSecond` の不正値は `RangeError`

## スコープ（責務分離）
- 命令の意味解釈・コマンド化 → `features/command-management`（#186）
- カメラ取得（getUserMedia）→ `shared/camera`（#180）。**本スライスは呼ばない**
- 迷路共有QRの解凍 → `maze-qr-management`（#201）
- 本スライスは QR の生文字列を透過返却するのみ（Zod 等の検証も持たない）

## テスト観点
- 単体テスト **24 件パス**（qr-scanner / decodeQr をモックし node 環境でロジック検証）
  - decodeQr: 成功 / 未検出→null / 未検出以外は再throw / エンジン再利用
  - loop: 連続スキャン / null時は通知せず / 失敗はonError / stop・destroy / throttle / readyStateガード / maxScansPerSecond の RangeError・0.5許容
- `mise run check`（format/lint/型）green・`mise run lint:fsd`（FSD境界）違反なし
- 実ブラウザ検証: Vite が qr-scanner の Worker 動的importを最適化チャンクとして配信することを確認。canvas 描画した QR を `decodeQr` で読み戻し `forward` を取得（実 Worker 経路の疎通確認済み）

## 関連 Issue
#181

> 注: デフォルトブランチが `release` のため `closes` は自動発火しません。マージ後に #181 を手動クローズします。