### PR TITLE
feat(shared/db): 迷路・フォルダの永続化層(TanStack DB × SQLite/OPFS)を実装 (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@
 | デスクトップ | Tauri |
 | バリデーション | Zod |
 | DB アクセス | TanStack DB |
-| ローカルDB | IndexedDB |
+| ローカルDB | SQLite（ブラウザ/WebView は wa-sqlite WASM + OPFS。TanStack DB persistence 経由） |
 | 状態管理 | Zustand / 複雑な遷移は XState |
 
 - **Vite+（vp）** は dev/build に加え、lint・format・型チェック（Oxlint/Oxfmt/tsgo）、テスト（`vp test`）、モノレポ対応のタスク実行、パッケージングを一本化する統合 CLI。Vite/Rolldown ベース。

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ProgPath は、小学校高学年をターゲットとしたプログラミン�
 | QR 認識 | qr-scanner |
 | 状態管理 | Zustand（複雑な遷移は XState） |
 | バリデーション | Zod |
-| 永続化 | TanStack DB + IndexedDB |
+| 永続化 | TanStack DB + SQLite（WASM+OPFS） |
 | デスクトップ | Tauri |
 | ツールチェーン | Vite+（vp） |
 | 環境管理 / パッケージ | mise / pnpm |

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ ProgPath（再開発版）の設計ドキュメント群の索引。各ドキュ
 | [features.md](./features.md) | 機能仕様。ホーム/迷路編集/AR実行/ダウンロードの画面別の振る舞いと確定ドメインルール。 |
 | [architecture.md](./architecture.md) | アーキテクチャ設計。システム構成図・技術スタックの責務・FSD 規則・データフロー・3D/AR 方式。 |
 | [directory-structure.md](./directory-structure.md) | ディレクトリ構成。`src/` 配下のレイヤー/スライス/セグメントと Public API 方針。 |
-| [db-design.md](./db-design.md) | DB 設計。迷路・フォルダのデータモデル・Zod スキーマ・TanStack DB/IndexedDB・QR シリアライズ。 |
+| [db-design.md](./db-design.md) | DB 設計。迷路・フォルダのデータモデル・Zod スキーマ・TanStack DB/SQLite(WASM+OPFS)・QR シリアライズ。 |
 | [glossary.md](./glossary.md) | 用語集。ドメイン・コマンド・タイル種別・FSD・技術スタックの統一定義。 |
 | [design-tokens.md](./design-tokens.md) | デザイントークン。配色（ライト/ダーク）・タイポ・スペーシング・タップ最小サイズ・タイル/コマンドの識別色とアイコンの統一定義。 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ graph TB
 
         subgraph Data["永続化"]
             TanStack["🗃️ TanStack DB"]
-            IDB["📁 IndexedDB"]
+            IDB["📁 SQLite (WASM+OPFS)"]
         end
     end
 
@@ -81,7 +81,7 @@ graph TB
 | 複雑な遷移 | XState | **AR 実行フロー**の明示的ステートマシン（→ [5.2](#52-状態管理の方針)） |
 | バリデーション | Zod | 入力・QR・永続データのスキーマ検証 |
 | DB アクセス | TanStack DB | 永続データへのリアクティブアクセス |
-| ローカル DB | IndexedDB | 迷路・フォルダの永続化 |
+| ローカル DB | SQLite（ブラウザは WASM+OPFS。TanStack DB persistence 経由） | 迷路・フォルダの永続化 |
 | デスクトップ | Tauri | Desktop 配布（WebView ベース） |
 | ツールチェーン | Vite+（vp） | dev/build・lint/format・型チェック・テスト・パッケージング |
 | 環境管理 | mise | ランタイム固定 + タスク実行の入口 |
@@ -194,7 +194,7 @@ graph TD
 2. **実行**: `maze-simulation` がスタックを先頭から解釈し、`robot` を 1 コマンド = 1 行動で動かす。実行前にスタート位置・初期向き（固定）へリセット。
 3. **判定**: 壁衝突 / 穴落下 / カギ未取得でゴール / コマンド尽きで未到達 → 失敗。全カギ取得＋ゴール到達 → 成功。
 4. **描画**: 状態更新を R3F が購読し、3D 迷路・ロボットへ反映。
-5. **永続化**: 迷路・フォルダは TanStack DB 経由で IndexedDB に保存・読込。
+5. **永続化**: 迷路・フォルダは TanStack DB 経由で SQLite（WASM+OPFS）に保存・読込。
 
 ### 5.2 状態管理の方針
 
@@ -222,7 +222,7 @@ stateDiagram-v2
 
 | 寿命 | 対象 | 置き場所 |
 | --- | --- | --- |
-| **永続** | 迷路 / フォルダ | IndexedDB（TanStack DB 経由） |
+| **永続** | 迷路 / フォルダ | SQLite / WASM+OPFS（TanStack DB 経由） |
 | **揮発（セッション内）** | 選択中の迷路・フォルダ展開状態・コマンドスタック・ロボット実行時状態 | メモリ（Zustand / XState） |
 | 永続化しない | 最後に開いた迷路・UI の表示状態・カメラ映像 | — |
 

--- a/docs/db-design.md
+++ b/docs/db-design.md
@@ -1,11 +1,11 @@
 # DB 設計
 
-ProgPath（再開発版）の**ローカル永続化データの設計**を定義する。データモデル・スキーマ（Zod）・コレクション設計（TanStack DB）・IndexedDB 永続化・初期データ/復旧・QR シリアライズを扱う。
+ProgPath（再開発版）の**ローカル永続化データの設計**を定義する。データモデル・スキーマ（Zod）・コレクション設計（TanStack DB）・SQLite 永続化・初期データ/復旧・QR シリアライズを扱う。
 
 - 対象読者: 新規開発者、および設計判断の参照者（人・AI）。
 - 前提: 永続化対象は **迷路（maze）・フォルダ（folder）のみ**（→ [architecture.md](./architecture.md) 5.3）。コマンドスタック・実行時状態・UI 状態は永続化しない。
 - ドメインルールは [features.md](./features.md)、配置（`shared/db`）は [directory-structure.md](./directory-structure.md) を正とする。
-- アクセスは TanStack DB（Provider 不要・コレクションはシングルトン）、ローカル DB は IndexedDB、検証は Zod（→ [CLAUDE.md](../CLAUDE.md)）。
+- アクセスは TanStack DB（Provider 不要・コレクションはシングルトン）、ローカル DB は **SQLite（ブラウザは WASM + OPFS）**、検証は Zod（→ [CLAUDE.md](../CLAUDE.md)）。永続化は TanStack DB の `persistedCollectionOptions`（`@tanstack/browser-db-sqlite-persistence`）で担う。
 
 > 〔要確認〕が付いた箇所は暫定。実装・検証で確定させる。スキーマ例の型は設計意図を示すもので、実装時に調整しうる。
 
@@ -15,7 +15,7 @@ ProgPath（再開発版）の**ローカル永続化データの設計**を定�
 
 | 区分 | 対象 | 保存先 |
 | --- | --- | --- |
-| **永続化する** | 迷路（maze）/ フォルダ（folder） | IndexedDB |
+| **永続化する** | 迷路（maze）/ フォルダ（folder） | SQLite（WASM + OPFS） |
 | 永続化しない（揮発） | コマンドスタック・ロボット実行時状態・選択/展開状態・カメラ映像 | メモリ（Zustand / XState） |
 
 永続化対象は 2 エンティティのみ。手動並び替えは v1 で行わないため、並び順を保持する項目は持たない（既定順＝作成日時）。
@@ -54,7 +54,7 @@ erDiagram
 
 ## 3. エンティティ定義
 
-> **日時は `number`（epoch ms）で持つ**。`Date` 型は IndexedDB（structured clone）には保存できるが、JSON 境界（QR・将来の連携）を跨ぐと文字列化して型が壊れる。number はシリアライズに強く、作成順ソートも数値比較で自明なため既定とする。日時の用途は並び順と更新追跡のみで、児童への日時表示は行わない。
+> **日時は `number`（epoch ms）で持つ**。`Date` 型は JSON 境界（QR・将来の連携）や SQLite の列表現を跨ぐと文字列化して型が壊れやすい。number はシリアライズに強く、作成順ソートも数値比較で自明なため既定とする。日時の用途は並び順と更新追跡のみで、児童への日時表示は行わない。
 
 ### 3.1 folder
 
@@ -152,8 +152,8 @@ export type Maze = z.infer<typeof MazeSchema>;
 export type Folder = z.infer<typeof FolderSchema>;
 ```
 
-- **ID は UUID v4**。作成時に `crypto.randomUUID()` で採番する（論理型は上表の `uuid`／推論される TS 型は `string`。ブランド型は導入しない）。未分類フォルダは予約 nil UUID（`shared/config` の `UNCATEGORIZED_FOLDER_ID`）。`.uuid()` 検証は**版数を厳格化せず nil を許容**する（生成は v4／予約は nil）。採用する Zod のバージョンで `.uuid()` の版数厳格性が異なるため、予約 nil を確実に通す検証を #179 で確定する。
-- **テレポート整合**（移動先が存在しない/壁・穴・テレポート）は編集時の検証（→ [features.md](./features.md) 4.6）。永続スキーマでは寸法・スタート/ゴール個数の構造検証を行う〔要確認: テレポート整合をスキーマ側でも検証するか〕。
+- **ID は UUID v4**。作成時に `crypto.randomUUID()` で採番する（論理型は上表の `uuid`／推論される TS 型は `string`。ブランド型は導入しない）。未分類フォルダは予約 nil UUID（`shared/config` の `UNCATEGORIZED_FOLDER_ID`）。**採用した Zod v4 の `z.uuid()` は版数を検査し nil（全 0）を弾く**ため、ID フィールドは `z.union([z.uuid(), z.literal(UNCATEGORIZED_FOLDER_ID)])`（= 「v4 または予約 nil」）で定義して nil を確実に通す（実装: `shared/db/model/schema.ts` の `uuidField`。#179 で確定）。
+- **テレポート整合**（移動先が存在しない/壁・穴・テレポート）は編集時に検証する（→ [features.md](./features.md) 4.6）。永続スキーマ（`MazeSchema`）では寸法・スタート/ゴール個数の**構造検証のみ**行い、テレポート整合はスキーマ側では検証しない（#179 で確定）。
 - 文字数上限（name）は features.md 3.6 の〔要確認〕に従い、確定後に `max` を付す。
 
 ---
@@ -162,44 +162,48 @@ export type Folder = z.infer<typeof FolderSchema>;
 
 `shared/db` にコレクションを**モジュールレベルのシングルトン**として定義する。Provider は不要で、UI は `useLiveQuery` で直接購読する（→ [directory-structure.md](./directory-structure.md) 4.1）。
 
-```typescript
-// shared/db/collections.ts（設計イメージ）
-export const folderCollection = createCollection(
-  /* IndexedDB バック・options */ {
-    id: "folders",
-    getKey: (f: Folder) => f.id,
-    schema: FolderSchema,
-  },
-);
+SQLite（OPFS）を開くのは非同期のため、コレクションは `initDb()`（`shared/db`）で一度だけ生成し、以後はシングルトンとして共有する。アプリ起動時に `initDb()` を呼び、初期データ保証・不正データ復旧（→ 7）を済ませてから UI をレンダリングする。
 
-export const mazeCollection = createCollection(
-  {
-    id: "mazes",
-    getKey: (m: Maze) => m.id,
-    schema: MazeSchema,
-  },
+```typescript
+// shared/db/model/collections.ts（設計イメージ）
+// persistence は openBrowserWASQLiteOPFSDatabase → createBrowserWASQLitePersistence で生成し、
+// 2 コレクションで共有する。
+const folderCollection = createCollection(
+  persistedCollectionOptions<Folder, string>({
+    id: "folders",
+    getKey: (f) => f.id,
+    persistence,
+    schemaVersion: SCHEMA_VERSION,
+  }),
 );
 ```
 
 - `getKey` は各エンティティの `id`。
 - 読み出しは `useLiveQuery((q) => q.from({ maze: mazeCollection }))` の形。フォルダで絞る場合は `folderId` で where。
 - 変更は `collection.insert / update / delete` で行い、UI はライブクエリで自動更新。
+- **Zod 検証の適用点**: `persistedCollectionOptions` はコレクションの `schema` フックに Zod を取らない（行の型を `<T, TKey>` で与える設計）。よって Zod 検証は **(a) 起動時の復旧掃引（→ 7）** と **(b) 書き込み境界（`entities` / `features` で `insert` 前に parse）** で明示的に行う。スキーマの正は `shared/db/model/schema.ts` に置き、上位スライスが再利用する。
 
 ---
 
-## 6. IndexedDB 永続化
+## 6. SQLite 永続化
 
-TanStack DB の組み込みアダプタには localStorage はあるが IndexedDB は無いため、**IndexedDB バックの永続化層を介してコレクションへ接続**する〔要確認: 接続方式・利用ライブラリ（例 `idb`）〕。
+TanStack DB の組み込みアダプタには localStorage はあるが IndexedDB は無い。IndexedDB を直結する公式経路も無い（TanStack は索引・接続管理の都合で組み込み IndexedDB アダプタを提供しない）。そこで **TanStack DB 公式の永続化 `persistedCollectionOptions`（SQLite バック）を採用**する（#179 で確定）。
 
-### オブジェクトストア
+### 接続方式（確定）
 
-| ストア | keyPath | インデックス |
-| --- | --- | --- |
-| `folders` | `id` | — |
-| `mazes` | `id` | `folderId`（フォルダ別取得用） |
+- ブラウザ／WebView: `@tanstack/browser-db-sqlite-persistence` の `openBrowserWASQLiteOPFSDatabase`（wa-sqlite + OPFS）で DB を開き、`createBrowserWASQLitePersistence` で persistence を生成、2 コレクションで共有する。
+- DB 名は `prog-path`（`shared/db` の `DB_NAME`）。
+- **採用理由**: Zod を単一スキーマに保てる（RxDB は RxJsonSchema と Zod の二重定義が必須）／TanStack 第一者統合で保守が容易／folder 1—N maze の関係データに自然／Tauri 配布のため WASM バンドル増は実質無害。RxDB・localStorage・自作 idb アダプタは却下（→ 経緯は #179）。
 
-- 1 DB・2 ストア構成。サイズが小さい（1 迷路最大 147 セル）ため軽量。
-- DB スキーマには**バージョン番号**を持たせ、将来のマイグレーションに備える〔要確認: 初期バージョン〕。
+### スキーマバージョン
+
+- `persistedCollectionOptions` の `schemaVersion` を **初期値 `1`**（`shared/db` の `SCHEMA_VERSION`）とする。破壊的なスキーマ変更時に増やすとローカルコピーが更新される。
+- データは小さい（1 迷路最大 147 セル）ため軽量。
+
+### 検証状況（スパイク）
+
+- **ブラウザ（Chromium）: 検証済み ✅**。実コード（`initDb()`）で OPFS DB オープン・未分類フォルダ自動生成・迷路の insert/delete がページ再読込を跨いで永続することを確認（→ [spikes/179-sqlite-opfs](../spikes/179-sqlite-opfs/README.md)）。`OPFSCoopSyncVFS` は専用 Worker で動き COOP/COEP は不要。
+- **Tauri WebView: 未検証**。macOS(WKWebView)・Linux(WebKitGTK) の OPFS 対応は WebView 依存のため、実機（`mise run dev:desktop`）で確認する（#175 と併せて）。不成立時は Tauri ネイティブ SQLite アダプタ、最終的に RxDB/IndexedDB へフォールバックする。
 
 ---
 

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -104,7 +104,7 @@ src/
    ├─ lib/                … 汎用ユーティリティ
    ├─ qr/                 … QR デコーダ抽象（qr-scanner）
    ├─ camera/             … カメラ取得抽象（getUserMedia / 環境差吸収）
-   ├─ db/                 … TanStack DB + IndexedDB アクセス
+   ├─ db/                 … TanStack DB + SQLite(WASM+OPFS) アクセス
    └─ config/             … 定数・設定
 ```
 
@@ -119,7 +119,7 @@ src/
 - **`entrypoint`**: アプリ起点。`entrypoint/main.tsx` を `index.html` が読み込み、`createRoot` で描画する。FSD 公式の `app/entrypoint` セグメントに対応。
 - **`styles`**: グローバルスタイル。`styles/global.css` が Tailwind を読み込み、デザイントークンを `@theme` に定義する（トークンの中身は #174）。`entrypoint` から import する。
 
-> **TanStack DB は Provider 不要**。`useLiveQuery` はコレクションを直接購読し、コレクションは `shared/db` でモジュールレベルのシングルトンとして定義する。`QueryClientProvider` が要るのは Query Collection（サーバ同期）を使う場合のみで、本プロジェクト（オフライン・IndexedDB）では使わない。
+> **TanStack DB は Provider 不要**。`useLiveQuery` はコレクションを直接購読し、コレクションは `shared/db` でモジュールレベルのシングルトンとして定義する。`QueryClientProvider` が要るのは Query Collection（サーバ同期）を使う場合のみで、本プロジェクト（オフライン・SQLite）では使わない。
 
 ### 4.2 pages
 
@@ -180,7 +180,7 @@ src/
 | `lib` | フレームワーク非依存の汎用ユーティリティ |
 | `qr` | **QR デコーダ抽象**。`qr-scanner` を内部実装とし、デコード I/F を提供 |
 | `camera` | **カメラ取得抽象**。`getUserMedia` の環境差（Web / Tauri WebView）を吸収 |
-| `db` | **永続化抽象**。TanStack DB のコレクション定義（モジュールレベルのシングルトン）と IndexedDB アクセス（→ [db-design.md](./db-design.md)） |
+| `db` | **永続化抽象**。TanStack DB のコレクション定義（モジュールレベルのシングルトン）と SQLite(WASM+OPFS) アクセス（→ [db-design.md](./db-design.md)） |
 | `config` | 定数・設定値（サイズ上限・loop 回数範囲・未分類フォルダ予約 ID `UNCATEGORIZED_FOLDER_ID` 等） |
 
 > `qr` / `camera` / `db` はインターフェースを公開し、実装を差し替え可能にする。インターフェースの型定義は実装時／[db-design.md](./db-design.md) に委ねる。

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@ ProgPath（再開発版）の**画面別の機能・振る舞い**を定義す�
 - 用語は [glossary.md](./glossary.md) に統一定義する（整備中）。
 
 > 〔要確認〕が付いた値・挙動は暫定。実機検証・運用で確定させる。
-> 数値・技術前提は to-be（**階層 1〜3 / サイズ 5×5〜7×7 / IndexedDB + TanStack DB / Tauri**）を正とする。
+> 数値・技術前提は to-be（**階層 1〜3 / サイズ 5×5〜7×7 / SQLite(WASM+OPFS) + TanStack DB / Tauri**）を正とする。
 
 ---
 
@@ -101,7 +101,7 @@ flowchart LR
 
 - 迷路の**作成・閲覧・編集・削除**ができる。
 - 削除は確認ダイアログを経て実行する。
-- 迷路データはローカルに永続化する（IndexedDB / TanStack DB、→ [db-design.md](./db-design.md)）。
+- 迷路データはローカルに永続化する（SQLite(WASM+OPFS) / TanStack DB、→ [db-design.md](./db-design.md)）。
 - 迷路が 1 件も無いときは、新規作成を促す案内 UI を表示する。
 
 ### 3.4 フォルダ管理
@@ -309,7 +309,7 @@ stateDiagram-v2
 
 ### 7.2 永続化
 
-- 迷路・フォルダはローカル DB（IndexedDB）に保存し、TanStack DB 経由でアクセスする（→ [db-design.md](./db-design.md)）。
+- 迷路・フォルダはローカル DB（SQLite / WASM+OPFS）に保存し、TanStack DB 経由でアクセスする（→ [db-design.md](./db-design.md)）。
 - オフラインで読み書きできる。
 
 ### 7.3 未確定事項（〔要確認〕一覧）

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -114,7 +114,8 @@ ProgPath（再開発版）で用いる主要用語の**統一定義**。ドキ�
 | TanStack DB | TanStack DB | 永続データへのリアクティブアクセス層。Provider 不要。 | [architecture](./architecture.md) 2 |
 | コレクション | collection | TanStack DB の正規化キャッシュ。`shared/db` でモジュールレベルのシングルトンとして定義。 | [db-design](./db-design.md) 5 |
 | ライブクエリ | `useLiveQuery` | コレクションを直接購読し、変更で自動再描画する Hook。 | [db-design](./db-design.md) 5 |
-| IndexedDB | IndexedDB | ブラウザ／WebView 内のローカル DB。迷路・フォルダを永続化。 | [db-design](./db-design.md) 6 |
+| SQLite | SQLite | ローカル DB。迷路・フォルダを永続化。ブラウザ／WebView では wa-sqlite(WASM) + OPFS で動作し、TanStack DB の `persistedCollectionOptions` 経由でアクセスする。 | [db-design](./db-design.md) 6 |
+| OPFS | OPFS | Origin Private File System。ブラウザ／WebView のオリジン専用ファイル領域。SQLite(WASM) の永続化バックエンドに用いる。 | [db-design](./db-design.md) 6 |
 | Zod | Zod | スキーマ定義・バリデーションライブラリ。永続データ・QR・入力を検証。 | [db-design](./db-design.md) 4 |
 | qr-scanner | qr-scanner | QR デコードライブラリ（jsQR を Web Worker でラップ）。`shared/qr` の内部実装。 | [architecture](./architecture.md) 2 |
 | Tauri | Tauri | デスクトップ配布のためのフレームワーク（WebView ベース）。 | [architecture](./architecture.md) 7 |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -131,7 +131,7 @@ ProgPath（再開発版）の「何を作るか」を定義する。本書は全
 
 ### 5.5 データ永続化
 
-- ローカル DB（IndexedDB）に迷路・フォルダを保存する。アクセスは TanStack DB を用いる（→ [db-design.md](./db-design.md)）。
+- ローカル DB（SQLite / ブラウザは WASM+OPFS）に迷路・フォルダを保存する。アクセスは TanStack DB を用いる（→ [db-design.md](./db-design.md)）。
 - 不正・空のデータは初期データで上書き復旧する。
 
 ### 5.6 プラットフォーム差異
@@ -171,7 +171,7 @@ ProgPath（再開発版）の「何を作るか」を定義する。本書は全
 
 ## 8. 制約・前提条件
 
-- 技術スタックは to-be（TypeScript / React / Radix UI + Tailwind / Three.js(R3F) / Tauri / Zod / TanStack DB + IndexedDB / Zustand）。詳細は [CLAUDE.md](../CLAUDE.md) と [architecture.md](./architecture.md)。
+- 技術スタックは to-be（TypeScript / React / Radix UI + Tailwind / Three.js(R3F) / Tauri / Zod / TanStack DB + SQLite / Zustand）。詳細は [CLAUDE.md](../CLAUDE.md) と [architecture.md](./architecture.md)。
 - FSD アーキテクチャを厳守する。
 - Tauri WebView のカメラ取得は実機検証が必要（未検証の前提で設計する）。
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "@radix-ui/colors": "^3.0.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
+    "@tanstack/browser-db-sqlite-persistence": "^0.2.6",
+    "@tanstack/db": "^0.6.14",
+    "@tanstack/react-db": "^0.1.92",
     "clsx": "^2.1.1",
     "lucide-react": "^1.23.0",
     "qr-scanner": "^1.4.2",
@@ -24,7 +27,8 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwind-merge": "^3.6.0",
-    "three": "^0.185.1"
+    "three": "^0.185.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ importers:
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)
+      '@tanstack/browser-db-sqlite-persistence':
+        specifier: ^0.2.6
+        version: 0.2.6(@journeyapps/wa-sqlite@1.7.2)(typescript@6.0.3)
+      '@tanstack/db':
+        specifier: ^0.6.14
+        version: 0.6.14(typescript@6.0.3)
+      '@tanstack/react-db':
+        specifier: ^0.1.92
+        version: 0.1.92(react@19.2.7)(typescript@6.0.3)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -41,6 +50,9 @@ importers:
       three:
         specifier: ^0.185.1
         version: 0.185.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.2
@@ -142,6 +154,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@journeyapps/wa-sqlite@1.7.2':
+    resolution: {integrity: sha512-EVRMzqHtHgJBFcTGOgQ5/YlxrYFSXLFFztC5yo6+jQx2mqFR+a1kkLV4IirquiBzIonjmYXfBtvZ26fmI8r9Nw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1388,6 +1403,36 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/browser-db-sqlite-persistence@0.2.6':
+    resolution: {integrity: sha512-l78NOmRmdoFc+QoZmkvS1D1RkWaayUFMX+230Z20CP00tZBDgGWvSL6ubVLwf1IpcaY4AFsVuZmcfVDteE4UxQ==}
+    peerDependencies:
+      '@journeyapps/wa-sqlite': ^1.4.1
+      typescript: '>=4.7'
+
+  '@tanstack/db-ivm@0.1.18':
+    resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/db-sqlite-persistence-core@0.2.6':
+    resolution: {integrity: sha512-T9J/qzRmuumSw55w1o5X428k8GvtxCb81hNV73+MQlLMGabdJYpYCYjuADyPivHMF0ZkzjCl4NGdSI5+wzH4aQ==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/db@0.6.14':
+    resolution: {integrity: sha512-Kqma/PcWhn2e21iJPM/FMKwdMuJUYII9zkKPUsD42/ceEOYRtimbBSe+xll7EY805xE2HuQ3NGSSU8UiYXpHUw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/pacer-lite@0.2.2':
+    resolution: {integrity: sha512-eQ1MyLKCHyXiH7NbdmB80W77OhiMgGBUb+qDx/8WMGbwg5Lf/NlfD0TfNYAqY77i8V3AxoDoYdICrQE5ADw4Yw==}
+    engines: {node: '>=18'}
+
+  '@tanstack/react-db@0.1.92':
+    resolution: {integrity: sha512-Ymgwu+4Wq5n2ij/iCh8WxBla0dD8eP1/aivkNWfVe2GIQO9e3AM0vwtSIiOB6r5oFqJbE0x8sY7rQHPzljwf/Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
@@ -1855,6 +1900,10 @@ packages:
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  fractional-indexing@3.4.0:
+    resolution: {integrity: sha512-8J3glhz2rrpKG6KmI7wmJo3zH1VjeOpN+vTJSw1fOyO+Viqq3zX6/5NGh6oaZB2qIAYdOYuu5Dz9xp4faOO0Pg==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2331,6 +2380,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sorted-btree@1.8.1:
+    resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2607,6 +2659,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -2701,6 +2756,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@journeyapps/wa-sqlite@1.7.2': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3797,6 +3854,41 @@ snapshots:
       tailwindcss: 4.3.2
       vite: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)
 
+  '@tanstack/browser-db-sqlite-persistence@0.2.6(@journeyapps/wa-sqlite@1.7.2)(typescript@6.0.3)':
+    dependencies:
+      '@journeyapps/wa-sqlite': 1.7.2
+      '@tanstack/db-sqlite-persistence-core': 0.2.6(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@tanstack/db-ivm@0.1.18(typescript@6.0.3)':
+    dependencies:
+      fractional-indexing: 3.4.0
+      sorted-btree: 1.8.1
+      typescript: 6.0.3
+
+  '@tanstack/db-sqlite-persistence-core@0.2.6(typescript@6.0.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.14(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@tanstack/db@0.6.14(typescript@6.0.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db-ivm': 0.1.18(typescript@6.0.3)
+      '@tanstack/pacer-lite': 0.2.2
+      typescript: 6.0.3
+
+  '@tanstack/pacer-lite@0.2.2': {}
+
+  '@tanstack/react-db@0.1.92(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@tanstack/db': 0.6.14(typescript@6.0.3)
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - typescript
+
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
@@ -4187,6 +4279,8 @@ snapshots:
   fflate@0.6.10: {}
 
   fflate@0.8.3: {}
+
+  fractional-indexing@3.4.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -4666,6 +4760,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sorted-btree@1.8.1: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -4907,6 +5003,8 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.21.0: {}
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
     dependencies:

--- a/spikes/179-sqlite-opfs/README.md
+++ b/spikes/179-sqlite-opfs/README.md
@@ -1,0 +1,35 @@
+# #179 スパイク: SQLite(WASM+OPFS) 永続化の実機検証
+
+`shared/db` の永続化基盤（TanStack DB `persistedCollectionOptions` + `@tanstack/browser-db-sqlite-persistence`＝wa-sqlite(WASM) + OPFS）が、**実ブラウザで永続するか**を実コード（`@/shared/db` の `initDb()`）で検証する。
+
+db-design §6 で唯一の実リスクとした「OPFS 永続化の成立」を de-risk するのが目的。
+
+## 実行方法
+
+```
+mise run dev        # = vp dev（http://localhost:5173）
+# ブラウザで開く:
+#   http://localhost:5173/spikes/179-sqlite-opfs/index.html
+```
+
+- `probe.ts` は `@/shared/db` の `initDb()` を呼び、迷路の追加／削除と再読込後の件数を画面に表示する。
+- OPFS はオリジン単位の永続領域。`localhost` は secure context のため利用可。`OPFSCoopSyncVFS` は専用 Worker + 同期アクセスハンドルで動くため **COOP/COEP（cross-origin isolation）不要**。
+
+## 結果（2026-07-11 / 実行環境: Chromium ベースのブラウザペイン）
+
+| 検証項目 | 結果 |
+| --- | --- |
+| wa-sqlite(WASM) + OPFS Worker のロード | ✅ エラーなし（Vite の `new Worker(new URL(...))` で worker/wasm がバンドル・配信される） |
+| `initDb()`（OPFS DB オープン → persistence → コレクション生成） | ✅ 成功 |
+| 起動時の未分類フォルダ自動生成（`ensureInitialData`） | ✅ 「フォルダ 1 件（未分類あり ✓）」 |
+| 迷路 0 件が正常状態 | ✅ |
+| `insert` の永続 | ✅ 追加 → **フルリロード後も同一 id の迷路が残存**（メモリではなくディスク永続を確認） |
+| `delete` の永続 | ✅ 全削除 → フルリロード後も 0 件 |
+| 未分類フォルダの冪等性（再読込で重複しない） | ✅ 常に 1 件 |
+| コンソールエラー | ✅ なし |
+
+**結論**: ブラウザ（Chromium）では SQLite(WASM+OPFS) 永続化が期待どおり動作し、CRUD がページ再読込を跨いで永続する。db-design §6 で採用した方式は成立。
+
+## 残課題（このスパイクの範囲外）
+
+- **Tauri WebView での実機検証**: 本スパイクは Chromium ベースのブラウザで確認した。Windows の WebView2 は Chromium 系のため本結果が強く当てはまるが、macOS(WKWebView)・Linux(WebKitGTK) の OPFS 対応は各 WebView に依存するため、Tauri 実機（`mise run dev:desktop`）での確認を #175 と併せて行う。不成立の場合は Tauri ネイティブ SQLite アダプタ、最終的に RxDB/IndexedDB へフォールバック（→ db-design §6）。

--- a/spikes/179-sqlite-opfs/index.html
+++ b/spikes/179-sqlite-opfs/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>#179 SQLite(OPFS) 永続化スパイク</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 720px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        line-height: 1.6;
+      }
+      button {
+        font-size: 1rem;
+        padding: 0.4rem 0.8rem;
+        margin-right: 0.5rem;
+      }
+      #log {
+        white-space: pre-wrap;
+        background: #f4f4f4;
+        padding: 1rem;
+        border-radius: 6px;
+        margin-top: 1rem;
+      }
+      .ok {
+        color: #0a7d28;
+        font-weight: bold;
+      }
+      .ng {
+        color: #b00020;
+        font-weight: bold;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>#179 SQLite(WASM+OPFS) 永続化スパイク</h1>
+    <p>
+      実コード（<code>@/shared/db</code> の <code>initDb()</code>）を使い、迷路を追加 →
+      ページ再読込しても OPFS に永続しているかを確認する。
+    </p>
+    <div>
+      <button id="add">迷路を1件追加</button>
+      <button id="reload">再読込</button>
+      <button id="clear">全迷路を削除</button>
+    </div>
+    <div id="log">初期化中…</div>
+    <script type="module" src="./probe.ts"></script>
+  </body>
+</html>

--- a/spikes/179-sqlite-opfs/probe.ts
+++ b/spikes/179-sqlite-opfs/probe.ts
@@ -1,0 +1,79 @@
+// #179 SQLite(WASM+OPFS) 永続化スパイク。
+// 実コード（@/shared/db の initDb / MazeSchema）をブラウザで動かし、
+// 迷路の追加がページ再読込を跨いで OPFS に永続するかを確認する。
+import { UNCATEGORIZED_FOLDER_ID } from "@/shared/config";
+import { initDb, MazeSchema, TILE_KIND } from "@/shared/db";
+import type { AppDatabase, Maze } from "@/shared/db";
+
+const SIZE = 5;
+const logEl = document.getElementById("log");
+
+const write = (text: string): void => {
+  if (logEl) {
+    logEl.textContent = text;
+  }
+};
+
+/** 妥当な迷路を 1 件生成する（書き込み境界での Zod 検証も MazeSchema.parse で兼ねる）。 */
+const makeMaze = (): Maze => {
+  const now = Date.now();
+  const floor: string[][] = Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, (): string => TILE_KIND.FLOOR),
+  );
+  floor[0][0] = TILE_KIND.START;
+  floor[0][1] = TILE_KIND.GOAL;
+  return MazeSchema.parse({
+    id: crypto.randomUUID(),
+    name: `迷路 ${new Date(now).toLocaleTimeString()}`,
+    size: SIZE,
+    floors: 1,
+    tiles: [floor],
+    folderId: UNCATEGORIZED_FOLDER_ID,
+    createdAt: now,
+    updatedAt: now,
+  });
+};
+
+const render = async (db: AppDatabase): Promise<void> => {
+  const folders = await db.folderCollection.toArrayWhenReady();
+  const mazes = await db.mazeCollection.toArrayWhenReady();
+  const hasUncategorized = folders.some((folder) => folder.id === UNCATEGORIZED_FOLDER_ID);
+  const lines = [
+    `フォルダ: ${folders.length} 件 (未分類あり: ${hasUncategorized ? "✓" : "✗"})`,
+    `迷路: ${mazes.length} 件`,
+    ...mazes.map((maze) => `  - ${maze.name} [${maze.id.slice(0, 8)}]`),
+    "",
+    mazes.length > 0
+      ? "▶ この状態で［再読込］し、件数が保持されれば OPFS 永続化 OK"
+      : "▶ ［迷路を1件追加］→［再読込］で永続を確認",
+  ];
+  write(lines.join("\n"));
+};
+
+const main = async (): Promise<void> => {
+  const db = await initDb();
+  await render(db);
+
+  document.getElementById("add")?.addEventListener("click", () => {
+    db.mazeCollection.insert(makeMaze());
+    void render(db);
+  });
+
+  document.getElementById("clear")?.addEventListener("click", () => {
+    void (async () => {
+      const mazes = await db.mazeCollection.toArrayWhenReady();
+      for (const maze of mazes) {
+        db.mazeCollection.delete(maze.id);
+      }
+      await render(db);
+    })();
+  });
+
+  document.getElementById("reload")?.addEventListener("click", () => {
+    window.location.reload();
+  });
+};
+
+void main().catch((error: unknown) => {
+  write(`ERROR: ${String(error)}`);
+});

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -1,11 +1,19 @@
 /**
  * Public API — `shared/db`
  *
- * 永続化抽象。TanStack DB のコレクション定義（モジュールレベルのシングルトン）と
- * IndexedDB アクセスを担う（→ docs/db-design.md）。
+ * 永続化抽象。迷路・フォルダの Zod スキーマ（単一の正）と、SQLite(WASM+OPFS) バックの
+ * TanStack DB コレクション（モジュールシングルトン）、起動時の初期データ保証・不正データ復旧を担う
+ * （→ docs/db-design.md）。
  *
  * 他スライスからの import はこの index.ts 経由のみ。`export * from` は使わず
- * 公開対象を個別に明示し、公開シンボルは実装着手時に追加する
- * （→ docs/directory-structure.md 2.2）。
+ * 公開対象を個別に明示する（→ docs/directory-structure.md 2.2）。
  */
-export {};
+
+// スキーマ・型・定数（entities/maze(#182)・entities/folder(#192) が再利用する単一の正）
+export { TILE_KIND, TileKindSchema, FolderSchema, MazeSchema } from "./model/schema";
+export type { TileKind, Folder, Maze } from "./model/schema";
+
+// コレクションと初期化（アプリ起動時に initDb() を呼び、UI は useLiveQuery で購読）
+export { initDb, ensureInitialData } from "./model/bootstrap";
+export type { AppDatabase, FolderCollection, MazeCollection } from "./model/collections";
+export { DB_NAME, SCHEMA_VERSION } from "./model/persistence";

--- a/src/shared/db/lib/count-tile-kind.ts
+++ b/src/shared/db/lib/count-tile-kind.ts
@@ -1,0 +1,26 @@
+import type { TileKind } from "../model/schema";
+
+/**
+ * 3 次元タイル配列（`tiles[floor][row][col]`）から特定種別の総数を数える。
+ * MazeSchema の構造検証（スタート/ゴールは各 1 つ）で用いる。
+ *
+ * @param tiles - `[floor][row][col]` のタイル配置
+ * @param kind - 数えるタイル種別
+ * @returns 全階を通じた出現数
+ */
+export const countTileKind = (
+  tiles: readonly (readonly (readonly TileKind[])[])[],
+  kind: TileKind,
+): number => {
+  let count = 0;
+  for (const floor of tiles) {
+    for (const row of floor) {
+      for (const tile of row) {
+        if (tile === kind) {
+          count += 1;
+        }
+      }
+    }
+  }
+  return count;
+};

--- a/src/shared/db/lib/recovery.test.ts
+++ b/src/shared/db/lib/recovery.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { UNCATEGORIZED_FOLDER_ID } from "@/shared/config";
+
+import { FolderSchema } from "../model/schema";
+import type { Folder } from "../model/schema";
+import { buildUncategorizedFolder, hasUncategorizedFolder, partitionValid } from "./recovery";
+
+describe("partitionValid", () => {
+  it("妥当・不正を振り分ける", () => {
+    const rows = [
+      { id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301", name: "算数", isDefault: false, createdAt: 1 },
+      { id: "not-a-uuid", name: "壊れ", isDefault: false, createdAt: 1 }, // 不正
+      { name: "name欠落", isDefault: false }, // 不正
+    ];
+    const { valid, invalid } = partitionValid(rows, FolderSchema);
+    expect(valid).toHaveLength(1);
+    expect(invalid).toHaveLength(2);
+  });
+
+  it("空入力では両方空", () => {
+    const { valid, invalid } = partitionValid([], FolderSchema);
+    expect(valid).toHaveLength(0);
+    expect(invalid).toHaveLength(0);
+  });
+});
+
+describe("buildUncategorizedFolder", () => {
+  it("予約 ID・isDefault・固定 createdAt を持ち、スキーマ検証を通る", () => {
+    const folder = buildUncategorizedFolder();
+    expect(folder.id).toBe(UNCATEGORIZED_FOLDER_ID);
+    expect(folder.isDefault).toBe(true);
+    expect(folder.createdAt).toBe(0);
+    expect(FolderSchema.safeParse(folder).success).toBe(true);
+  });
+});
+
+describe("hasUncategorizedFolder", () => {
+  const normal: Folder = {
+    id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+    name: "算数",
+    isDefault: false,
+    createdAt: 1,
+  };
+
+  it("予約 ID があれば true", () => {
+    expect(hasUncategorizedFolder([normal, buildUncategorizedFolder()])).toBe(true);
+  });
+
+  it("予約 ID が無ければ false（0 件も false）", () => {
+    expect(hasUncategorizedFolder([normal])).toBe(false);
+    expect(hasUncategorizedFolder([])).toBe(false);
+  });
+});

--- a/src/shared/db/lib/recovery.ts
+++ b/src/shared/db/lib/recovery.ts
@@ -1,0 +1,49 @@
+import { UNCATEGORIZED_FOLDER_ID } from "@/shared/config";
+
+import type { Folder } from "../model/schema";
+
+/** 未分類フォルダの固定名（削除・リネーム不可。→ docs/db-design.md 3.1）。 */
+export const UNCATEGORIZED_FOLDER_NAME = "未分類";
+
+/**
+ * Zod スキーマ相当の検証インターフェース（`safeParse` のみに依存し zod のクラス階層に結合しない）。
+ */
+export interface Validatable<T> {
+  safeParse: (data: unknown) => { success: true; data: T } | { success: false };
+}
+
+/**
+ * レコード列をスキーマで検証し、妥当なものと不正なものに振り分ける。
+ * 不正データの破棄・復旧（→ docs/db-design.md 7）の判定に用いる純粋関数。
+ */
+export const partitionValid = <T>(
+  rows: readonly unknown[],
+  schema: Validatable<T>,
+): { valid: T[]; invalid: unknown[] } => {
+  const valid: T[] = [];
+  const invalid: unknown[] = [];
+  for (const row of rows) {
+    const result = schema.safeParse(row);
+    if (result.success) {
+      valid.push(result.data);
+    } else {
+      invalid.push(row);
+    }
+  }
+  return { valid, invalid };
+};
+
+/**
+ * 未分類フォルダのレコードを生成する。予約 nil UUID・`isDefault: true`・固定名を持ち、
+ * `createdAt` は 0（既定順で常に先頭）。起動時の存在保証で挿入する（→ docs/db-design.md 7）。
+ */
+export const buildUncategorizedFolder = (): Folder => ({
+  id: UNCATEGORIZED_FOLDER_ID,
+  name: UNCATEGORIZED_FOLDER_NAME,
+  isDefault: true,
+  createdAt: 0,
+});
+
+/** 未分類フォルダ（予約 ID）が既に存在するか。 */
+export const hasUncategorizedFolder = (folders: readonly Folder[]): boolean =>
+  folders.some((folder) => folder.id === UNCATEGORIZED_FOLDER_ID);

--- a/src/shared/db/model/bootstrap.test.ts
+++ b/src/shared/db/model/bootstrap.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { UNCATEGORIZED_FOLDER_ID } from "@/shared/config";
+
+import type { AppDatabase } from "./collections";
+import { ensureInitialData } from "./bootstrap";
+
+const V4_A = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+const V4_B = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d";
+
+/** ensureInitialData が使う最小メソッドだけを持つインメモリ・フェイクコレクション。 */
+const makeFakeCollection = (initial: ReadonlyArray<Record<string, unknown>>) => {
+  const rows = new Map<string, Record<string, unknown>>();
+  for (const row of initial) {
+    rows.set(String(row.id), row);
+  }
+  return {
+    rows,
+    toArrayWhenReady: async () => [...rows.values()],
+    delete: (key: string): void => {
+      rows.delete(key);
+    },
+    insert: (data: Record<string, unknown>): void => {
+      rows.set(String(data.id), data);
+    },
+  };
+};
+
+type FakeCollection = ReturnType<typeof makeFakeCollection>;
+
+const makeDb = (
+  folders: ReadonlyArray<Record<string, unknown>>,
+  mazes: ReadonlyArray<Record<string, unknown>> = [],
+): { db: AppDatabase; folderCollection: FakeCollection; mazeCollection: FakeCollection } => {
+  const folderCollection = makeFakeCollection(folders);
+  const mazeCollection = makeFakeCollection(mazes);
+  const db = { folderCollection, mazeCollection } as unknown as AppDatabase;
+  return { db, folderCollection, mazeCollection };
+};
+
+describe("ensureInitialData", () => {
+  it("空 DB では未分類フォルダを 1 つ生成し、迷路は 0 件のまま", async () => {
+    const { db, folderCollection, mazeCollection } = makeDb([]);
+    await ensureInitialData(db);
+    expect(folderCollection.rows.has(UNCATEGORIZED_FOLDER_ID)).toBe(true);
+    expect(folderCollection.rows.size).toBe(1);
+    expect(mazeCollection.rows.size).toBe(0);
+  });
+
+  it("不正フォルダを破棄し、妥当フォルダは残し、未分類を補う", async () => {
+    const valid = { id: V4_A, name: "算数", isDefault: false, createdAt: 1 };
+    const invalid = { id: V4_B, name: "", isDefault: false, createdAt: 1 }; // name 空で不正
+    const { db, folderCollection } = makeDb([valid, invalid]);
+    await ensureInitialData(db);
+    expect(folderCollection.rows.has(V4_A)).toBe(true);
+    expect(folderCollection.rows.has(V4_B)).toBe(false);
+    expect(folderCollection.rows.has(UNCATEGORIZED_FOLDER_ID)).toBe(true);
+  });
+
+  it("未分類フォルダが既にあれば重複させない", async () => {
+    const existing = { id: UNCATEGORIZED_FOLDER_ID, name: "未分類", isDefault: true, createdAt: 0 };
+    const { db, folderCollection } = makeDb([existing]);
+    await ensureInitialData(db);
+    expect(folderCollection.rows.size).toBe(1);
+  });
+
+  it("不正な迷路レコードを破棄する", async () => {
+    const invalidMaze = {
+      id: V4_A,
+      name: "壊れ迷路",
+      size: 4,
+      floors: 1,
+      tiles: [],
+      folderId: UNCATEGORIZED_FOLDER_ID,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const { db, mazeCollection } = makeDb([], [invalidMaze]);
+    await ensureInitialData(db);
+    expect(mazeCollection.rows.has(V4_A)).toBe(false);
+  });
+});

--- a/src/shared/db/model/bootstrap.ts
+++ b/src/shared/db/model/bootstrap.ts
@@ -1,0 +1,73 @@
+import { buildUncategorizedFolder, hasUncategorizedFolder, partitionValid } from "../lib/recovery";
+import type { Validatable } from "../lib/recovery";
+import { createCollections } from "./collections";
+import type { AppDatabase } from "./collections";
+import { FolderSchema, MazeSchema } from "./schema";
+import type { Folder } from "./schema";
+
+/** コレクションの読み書き最小インターフェース（テスト時に差し替え可能なよう構造的に受ける）。 */
+interface PurgeableCollection {
+  toArrayWhenReady: () => Promise<ReadonlyArray<unknown>>;
+  delete: (key: string) => unknown;
+}
+
+/** レコードから文字列 `id` を安全に取り出す（無ければ null）。 */
+const extractId = (row: unknown): string | null => {
+  if (typeof row === "object" && row !== null && "id" in row) {
+    const { id } = row as { id: unknown };
+    if (typeof id === "string") {
+      return id;
+    }
+  }
+  return null;
+};
+
+/**
+ * コレクションの現在レコードをスキーマ検証し、不正なものを破棄する（→ docs/db-design.md 7）。
+ * key を特定できる（`id` を持つ）不正レコードのみ削除する。
+ */
+const purgeInvalid = async <T>(
+  collection: PurgeableCollection,
+  schema: Validatable<T>,
+): Promise<void> => {
+  const rows = await collection.toArrayWhenReady();
+  const { invalid } = partitionValid(rows, schema);
+  for (const row of invalid) {
+    const id = extractId(row);
+    if (id !== null) {
+      collection.delete(id);
+    }
+  }
+};
+
+/**
+ * 起動時の初期データ保証・不正データ復旧を行う。
+ * 1. 不正レコードを破棄（迷路・フォルダ）
+ * 2. 未分類フォルダ（予約 ID）の存在を保証（無ければ再生成）
+ *
+ * 迷路 0 件は正常状態として扱い、サンプル迷路の自動投入はしない（→ docs/db-design.md 7）。
+ */
+export const ensureInitialData = async (db: AppDatabase): Promise<void> => {
+  await purgeInvalid(db.folderCollection, FolderSchema);
+  await purgeInvalid(db.mazeCollection, MazeSchema);
+
+  const folders: ReadonlyArray<Folder> = await db.folderCollection.toArrayWhenReady();
+  if (!hasUncategorizedFolder(folders)) {
+    db.folderCollection.insert(buildUncategorizedFolder());
+  }
+};
+
+let databasePromise: Promise<AppDatabase> | null = null;
+
+/**
+ * 迷路・フォルダの永続化 DB を初期化して返す（コレクション生成＋初期データ保証）。
+ * 冪等: 2 回目以降は同じ Promise を返し、コレクションはモジュールシングルトンになる。
+ * ブラウザ実行時のみ呼べる（OPFS 依存。→ {@link createCollections}）。
+ */
+export const initDb = (): Promise<AppDatabase> => {
+  databasePromise ??= createCollections().then(async (db) => {
+    await ensureInitialData(db);
+    return db;
+  });
+  return databasePromise;
+};

--- a/src/shared/db/model/collections.ts
+++ b/src/shared/db/model/collections.ts
@@ -1,0 +1,55 @@
+import { persistedCollectionOptions } from "@tanstack/browser-db-sqlite-persistence";
+import type { PersistedCollectionPersistence } from "@tanstack/browser-db-sqlite-persistence";
+import { createCollection } from "@tanstack/react-db";
+import type { Collection } from "@tanstack/react-db";
+
+import { createPersistence, SCHEMA_VERSION } from "./persistence";
+import type { Folder, Maze } from "./schema";
+
+// NOTE: `persistedCollectionOptions` は Zod スキーマ（collection の `schema` フック）を
+// 受け取らず、行の型を `<T, TKey>` で与える設計（→ 公式 quick start）。
+// そのため Zod 検証は「起動時の復旧掃引（bootstrap）」と「書き込み境界（entities/features）」で
+// 明示的に行い、スキーマの正は `shared/db`（→ model/schema.ts）に置く。
+
+/** フォルダコレクション（SQLite 永続・モジュールシングルトン）。 */
+export type FolderCollection = Collection<Folder, string>;
+/** 迷路コレクション（SQLite 永続・モジュールシングルトン）。 */
+export type MazeCollection = Collection<Maze, string>;
+
+const buildFolderCollection = (persistence: PersistedCollectionPersistence): FolderCollection =>
+  createCollection(
+    persistedCollectionOptions<Folder, string>({
+      id: "folders",
+      getKey: (folder: Folder) => folder.id,
+      persistence,
+      schemaVersion: SCHEMA_VERSION,
+    }),
+  );
+
+const buildMazeCollection = (persistence: PersistedCollectionPersistence): MazeCollection =>
+  createCollection(
+    persistedCollectionOptions<Maze, string>({
+      id: "mazes",
+      getKey: (maze: Maze) => maze.id,
+      persistence,
+      schemaVersion: SCHEMA_VERSION,
+    }),
+  );
+
+/** 永続化コレクション一式。UI は `useLiveQuery` でこれらを直接購読する。 */
+export interface AppDatabase {
+  readonly folderCollection: FolderCollection;
+  readonly mazeCollection: MazeCollection;
+}
+
+/**
+ * 迷路・フォルダのコレクションを生成する。OPFS DB を開いてから両コレクションを作るため
+ * 非同期。ブラウザ実行時のみ呼べる（→ {@link createPersistence}）。
+ */
+export const createCollections = async (): Promise<AppDatabase> => {
+  const persistence = await createPersistence();
+  return {
+    folderCollection: buildFolderCollection(persistence),
+    mazeCollection: buildMazeCollection(persistence),
+  };
+};

--- a/src/shared/db/model/persistence.ts
+++ b/src/shared/db/model/persistence.ts
@@ -1,0 +1,26 @@
+import {
+  createBrowserWASQLitePersistence,
+  openBrowserWASQLiteOPFSDatabase,
+} from "@tanstack/browser-db-sqlite-persistence";
+import type { PersistedCollectionPersistence } from "@tanstack/browser-db-sqlite-persistence";
+
+/** OPFS 上の SQLite データベース名（→ docs/db-design.md 6）。 */
+export const DB_NAME = "prog-path";
+
+/**
+ * 永続化スキーマのバージョン。破壊的なスキーマ変更時に増やすとローカルコピーが更新される
+ * （`persistedCollectionOptions` の `schemaVersion`。→ docs/db-design.md 6）。
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * OPFS バックの SQLite データベースを開き、コレクション間で共有する persistence を生成する。
+ *
+ * OPFS（OPFSCoopSyncVFS）はブラウザ／WebView の Worker 環境に依存するため、この関数は
+ * ブラウザ実行時のみ呼べる（node のユニットテストからは呼ばない）。Tauri WebView での
+ * OPFS 挙動はスパイクで検証する（→ docs/db-design.md 6 / #179）。
+ */
+export const createPersistence = async (): Promise<PersistedCollectionPersistence> => {
+  const database = await openBrowserWASQLiteOPFSDatabase({ databaseName: DB_NAME });
+  return createBrowserWASQLitePersistence({ database });
+};

--- a/src/shared/db/model/schema.test.ts
+++ b/src/shared/db/model/schema.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { UNCATEGORIZED_FOLDER_ID } from "@/shared/config";
+
+import type { TileKind } from "./schema";
+import { FolderSchema, MazeSchema, TILE_KIND } from "./schema";
+
+const V4_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+/** floor 埋めの size×size グリッドを作り、start/goal を 1 つずつ置いた 1 階分のタイルを返す。 */
+const makeFloor = (size: number): TileKind[][] => {
+  const floor: TileKind[][] = Array.from({ length: size }, () =>
+    Array.from({ length: size }, (): TileKind => TILE_KIND.FLOOR),
+  );
+  floor[0][0] = TILE_KIND.START;
+  floor[0][1] = TILE_KIND.GOAL;
+  return floor;
+};
+
+const validMaze = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: V4_ID,
+  name: "テスト迷路",
+  size: 5,
+  floors: 1,
+  tiles: [makeFloor(5)],
+  folderId: UNCATEGORIZED_FOLDER_ID,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  ...overrides,
+});
+
+describe("FolderSchema", () => {
+  it("妥当なフォルダを通す", () => {
+    const folder = { id: V4_ID, name: "算数", isDefault: false, createdAt: 1 };
+    expect(FolderSchema.safeParse(folder).success).toBe(true);
+  });
+
+  it("未分類フォルダの予約 nil UUID を id として許容する", () => {
+    const folder = { id: UNCATEGORIZED_FOLDER_ID, name: "未分類", isDefault: true, createdAt: 0 };
+    expect(FolderSchema.safeParse(folder).success).toBe(true);
+  });
+
+  it("空の name を弾く", () => {
+    const folder = { id: V4_ID, name: "", isDefault: false, createdAt: 1 };
+    expect(FolderSchema.safeParse(folder).success).toBe(false);
+  });
+
+  it("UUID でない id を弾く", () => {
+    const folder = { id: "not-a-uuid", name: "算数", isDefault: false, createdAt: 1 };
+    expect(FolderSchema.safeParse(folder).success).toBe(false);
+  });
+});
+
+describe("MazeSchema", () => {
+  it("妥当な迷路を通す", () => {
+    expect(MazeSchema.safeParse(validMaze()).success).toBe(true);
+  });
+
+  it("folderId に予約 nil UUID を許容する", () => {
+    expect(MazeSchema.safeParse(validMaze({ folderId: UNCATEGORIZED_FOLDER_ID })).success).toBe(
+      true,
+    );
+  });
+
+  it("size 範囲外（4）を弾く", () => {
+    expect(MazeSchema.safeParse(validMaze({ size: 4, tiles: [makeFloor(4)] })).success).toBe(false);
+  });
+
+  it("floors と tiles の階層数不一致を弾く", () => {
+    expect(MazeSchema.safeParse(validMaze({ floors: 2 })).success).toBe(false);
+  });
+
+  it("各階の寸法が size と不一致なら弾く", () => {
+    const tiles = [makeFloor(6)]; // size=5 なのに 6×6
+    expect(MazeSchema.safeParse(validMaze({ tiles })).success).toBe(false);
+  });
+
+  it("スタートが無い迷路を弾く", () => {
+    const floor = makeFloor(5);
+    floor[0][0] = TILE_KIND.FLOOR; // start を消す
+    expect(MazeSchema.safeParse(validMaze({ tiles: [floor] })).success).toBe(false);
+  });
+
+  it("ゴールが 2 つある迷路を弾く", () => {
+    const floor = makeFloor(5);
+    floor[0][2] = TILE_KIND.GOAL; // goal を 1 つ追加
+    expect(MazeSchema.safeParse(validMaze({ tiles: [floor] })).success).toBe(false);
+  });
+
+  it("未知のタイル種別を弾く", () => {
+    const floor = makeFloor(5);
+    (floor[1] as unknown[])[1] = "lava";
+    expect(MazeSchema.safeParse(validMaze({ tiles: [floor] })).success).toBe(false);
+  });
+});

--- a/src/shared/db/model/schema.ts
+++ b/src/shared/db/model/schema.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+import {
+  MAZE_FLOOR_COUNT_MAX,
+  MAZE_FLOOR_COUNT_MIN,
+  MAZE_SIZE_MAX,
+  MAZE_SIZE_MIN,
+  UNCATEGORIZED_FOLDER_ID,
+} from "@/shared/config";
+
+import { countTileKind } from "../lib/count-tile-kind";
+
+/**
+ * エンティティ ID フィールド。
+ *
+ * 生成 ID は UUID v4（`crypto.randomUUID()`）だが、未分類フォルダのみ予約 nil UUID
+ * （`UNCATEGORIZED_FOLDER_ID`）を用いる。Zod の `z.uuid()` は版数（version nibble）を
+ * 検査し nil（全 0）を弾くため、nil を明示的に許容する union で「v4 または予約 nil」を通す。
+ * （→ docs/db-design.md 4 / #179）
+ */
+const uuidField = z.union([z.uuid(), z.literal(UNCATEGORIZED_FOLDER_ID)]);
+
+/**
+ * タイル種別の名前付き定数。値は永続・QR に保存される文字列そのもの（リネーム不可）。
+ * 参照側は `"start"` のような素の文字列でなく `TILE_KIND.START` を使う（→ 可読性・単一定義）。
+ * UI パレット（#197）等でも `Object.values(TILE_KIND)` で列挙できる。
+ * テレポートは上下を別種別として構造を単純化する（→ docs/db-design.md 3.3）。
+ */
+export const TILE_KIND = {
+  FLOOR: "floor",
+  WALL: "wall",
+  HOLE: "hole",
+  START: "start",
+  GOAL: "goal",
+  TELEPORT_UP: "teleportUp",
+  TELEPORT_DOWN: "teleportDown",
+  KEY: "key",
+} as const;
+
+/** タイル種別スキーマ。`z.enum` に enum-like オブジェクトを渡し、値のユニオンとして検証する。 */
+export const TileKindSchema = z.enum(TILE_KIND);
+
+/**
+ * フォルダ。未分類は `isDefault: true` かつ予約 nil UUID で常に 1 つ存在する
+ * （→ docs/db-design.md 3.1）。
+ */
+export const FolderSchema = z.object({
+  id: uuidField,
+  name: z.string().min(1),
+  isDefault: z.boolean(),
+  createdAt: z.number().int(),
+});
+
+/**
+ * 迷路。サイズは全階共通（5〜7）、階層は 1〜3。日時は epoch ms（number）で持つ
+ * （JSON/QR 境界に強く作成順ソートも数値比較で自明。→ docs/db-design.md 3）。
+ *
+ * 構造検証（`refine`）は永続化の復旧ゲートを兼ねる:
+ * - 階層数と `tiles` の一致、各階が `size × size` であること
+ * - スタート/ゴールは各 1 つ
+ *
+ * テレポート整合（移動先の存在・種別）は編集時に検証する（→ docs/features.md 4.6）。
+ */
+export const MazeSchema = z
+  .object({
+    id: uuidField,
+    name: z.string().min(1),
+    size: z.number().int().min(MAZE_SIZE_MIN).max(MAZE_SIZE_MAX),
+    floors: z.number().int().min(MAZE_FLOOR_COUNT_MIN).max(MAZE_FLOOR_COUNT_MAX),
+    tiles: z.array(z.array(z.array(TileKindSchema))),
+    folderId: uuidField,
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+  })
+  .refine((m) => m.tiles.length === m.floors, "階層数が tiles と不一致")
+  .refine(
+    (m) =>
+      m.tiles.every(
+        (floor) => floor.length === m.size && floor.every((row) => row.length === m.size),
+      ),
+    "各階の寸法が size と不一致",
+  )
+  .refine((m) => countTileKind(m.tiles, TILE_KIND.START) === 1, "スタートは 1 つ")
+  .refine((m) => countTileKind(m.tiles, TILE_KIND.GOAL) === 1, "ゴールは 1 つ");
+
+export type TileKind = z.infer<typeof TileKindSchema>;
+export type Folder = z.infer<typeof FolderSchema>;
+export type Maze = z.infer<typeof MazeSchema>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ const FORMAT_LINT_IGNORE = [
   "package.json",
   "pnpm-lock.yaml",
   "src-tauri/**",
+  // spikes/** は使い捨ての検証コード（tsconfig の include 外＝型情報なし）。FSD/本番規約の対象外。
+  "spikes/**",
 ];
 
 // Vite+ の統合設定。標準 Vite 設定に加え test(Vitest) / lint(Oxlint) / fmt(Oxfmt) を集約する。


### PR DESCRIPTION
## 概要

迷路・フォルダの永続化層（\`src/shared/db\`）を実装する（#179）。TanStack DB のコレクションを **SQLite（ブラウザは WASM + OPFS）** にバックし、Zod でスキーマ検証、起動時に初期データ保証・不正データ復旧を行う。

## 接続方式の決定（課題 db-design §6 の確定）

TanStack DB には IndexedDB 組み込みアダプタが無いため、接続方式を検討し **SQLite-WASM（公式 \`persistedCollectionOptions\` + \`@tanstack/browser-db-sqlite-persistence\`）** を採用した。

- **採用理由**: Zod を単一スキーマに保てる（RxDB は RxJsonSchema と Zod の二重定義が必須）／TanStack 第一者統合で保守が容易／folder 1—N maze の関係データに自然／Tauri 配布のため WASM バンドル増は実質無害。
- 却下: IndexedDB 直結（公式非対応）・RxDB（二重スキーマ・重量依存）・自作 idb アダプタ・localStorage。
- 経緯・比較は db-design §6 に記載。

## 主な変更

- **スキーマ/型（単一の正）**: \`MazeSchema\` / \`FolderSchema\`（構造 refine・nil UUID を union で許容）、タイル種別の名前付き定数 \`TILE_KIND\`。上位スライス（#182/#192）が再利用。
- **コレクション**: \`folder\` / \`maze\` を \`persistedCollectionOptions\` でモジュールシングルトン化。
- **起動処理**: \`initDb()\`（冪等）/ \`ensureInitialData()\` — 未分類フォルダの存在保証・不正レコード破棄（迷路 0 件は正常、サンプル自動投入なし）。
- **Zod 検証の適用点**: \`persistedCollectionOptions\` は collection の schema フックを取らないため、検証は起動時の復旧掃引と書き込み境界で明示適用。
- **docs**: IndexedDB → SQLite(WASM+OPFS) に全面改訂（db-design/architecture/requirements/directory-structure/glossary/features/README/CLAUDE.md）。

## 検証

- \`mise run check\`（型/lint/format）✅ / \`mise run test\`（**52 tests**、うち db 21）✅ / \`depcruise\`（FSD 境界）✅ / \`vp build\` ✅
- **OPFS 実機スパイク**（\`spikes/179-sqlite-opfs\`）: 実コード（\`initDb\`）を Chromium で動かし、**迷路の追加/削除がページ再読込を跨いで OPFS に永続**することを確認。未分類フォルダ自動生成・迷路 0 件正常・コンソールエラー無しも確認。

## 残課題

- **Tauri WebView（WKWebView / WebKitGTK）での OPFS 実機検証**は未実施（#175 と併せて確認予定）。不成立時は Tauri ネイティブ SQLite → RxDB へフォールバック（db-design §6 に明記）。

## 関連 Issue

- refs #179（デフォルトブランチが \`release\` のため \`closes\` は自動で効かない。マージ後に手動クローズ）